### PR TITLE
Standardize shared content viewer surfaces and preserve document frontmatter

### DIFF
--- a/.claude/progress/shared-content-viewer-standardization-v1/phase-3-progress.md
+++ b/.claude/progress/shared-content-viewer-standardization-v1/phase-3-progress.md
@@ -1,0 +1,90 @@
+---
+type: progress
+schema_version: 2
+doc_type: progress
+prd: "shared-content-viewer-standardization-v1"
+feature_slug: "shared-content-viewer-standardization-v1"
+prd_ref: null
+plan_ref: /docs/project_plans/implementation_plans/enhancements/shared-content-viewer-standardization-v1.md
+phase: 3
+title: "Session transcript and file-backed detail adoption"
+status: "in-progress"
+started: "2026-03-19"
+completed: null
+commit_refs: []
+pr_refs: []
+
+overall_progress: 0
+completion_estimate: "on-track"
+
+total_tasks: 4
+completed_tasks: 0
+in_progress_tasks: 1
+blocked_tasks: 0
+at_risk_tasks: 0
+
+owners: ["frontend-platform"]
+contributors: ["ai-agents"]
+
+tasks:
+  - id: "TASK-3.1"
+    description: "Add a safe project-relative file-content API for Session Inspector raw file-backed viewer flows."
+    status: "in_progress"
+    assigned_to: ["frontend-platform"]
+    dependencies: ["phase-2-complete"]
+    estimated_effort: "1pt"
+    priority: "high"
+
+  - id: "TASK-3.2"
+    description: "Add a lightweight shared viewer modal and content-loading helper for Session Inspector activity and files surfaces."
+    status: "pending"
+    assigned_to: ["frontend-platform"]
+    dependencies: ["TASK-3.1"]
+    estimated_effort: "2pt"
+    priority: "high"
+
+  - id: "TASK-3.3"
+    description: "Apply narrow transcript detail-pane shared viewer behavior only for file-backed or explicit file-content log payloads."
+    status: "pending"
+    assigned_to: ["frontend-platform"]
+    dependencies: ["TASK-3.2"]
+    estimated_effort: "2pt"
+    priority: "medium"
+
+  - id: "TASK-3.4"
+    description: "Add regression tests for the new file-content API and Session Inspector shared-viewer adoption, then run validation."
+    status: "pending"
+    assigned_to: ["frontend-platform"]
+    dependencies: ["TASK-3.3"]
+    estimated_effort: "2pt"
+    priority: "high"
+
+parallelization:
+  batch_1: ["TASK-3.1"]
+  batch_2: ["TASK-3.2"]
+  batch_3: ["TASK-3.3"]
+  batch_4: ["TASK-3.4"]
+  critical_path: ["TASK-3.1", "TASK-3.2", "TASK-3.3", "TASK-3.4"]
+  estimated_total_time: "7pt / ~1 day"
+
+blockers: []
+
+success_criteria:
+  - "Session Inspector opens DocumentModal for mapped documents and a shared viewer modal for raw project-relative file paths."
+  - "Raw file viewer content is fetched through a project-scoped, traversal-safe read-only API."
+  - "Transcript detail pane only switches to shared viewer mode for explicit file-content payloads and does not replace ordinary conversational transcript cards."
+  - "Frontend and backend tests cover the new API and viewer heuristics."
+
+files_modified:
+  - "backend/routers/codebase.py"
+  - "backend/services/codebase_explorer.py"
+  - "backend/tests/test_codebase_router.py"
+  - "components/SessionInspector.tsx"
+  - "components/content/UnifiedContentViewer.tsx"
+  - "services/codebase.ts"
+  - "types.ts"
+---
+
+# shared-content-viewer-standardization-v1 - Phase 3
+
+**YAML frontmatter is the source of truth for progress.**

--- a/.claude/progress/shared-content-viewer-standardization-v1/phase-3-progress.md
+++ b/.claude/progress/shared-content-viewer-standardization-v1/phase-3-progress.md
@@ -8,18 +8,20 @@ prd_ref: null
 plan_ref: /docs/project_plans/implementation_plans/enhancements/shared-content-viewer-standardization-v1.md
 phase: 3
 title: "Session transcript and file-backed detail adoption"
-status: "in-progress"
+status: "completed"
 started: "2026-03-19"
-completed: null
-commit_refs: []
+completed: "2026-03-19"
+commit_refs:
+  - "9b887fd"
+  - "b4da5ce"
 pr_refs: []
 
-overall_progress: 0
+overall_progress: 100
 completion_estimate: "on-track"
 
 total_tasks: 4
-completed_tasks: 0
-in_progress_tasks: 1
+completed_tasks: 4
+in_progress_tasks: 0
 blocked_tasks: 0
 at_risk_tasks: 0
 
@@ -29,7 +31,7 @@ contributors: ["ai-agents"]
 tasks:
   - id: "TASK-3.1"
     description: "Add a safe project-relative file-content API for Session Inspector raw file-backed viewer flows."
-    status: "in_progress"
+    status: "completed"
     assigned_to: ["frontend-platform"]
     dependencies: ["phase-2-complete"]
     estimated_effort: "1pt"
@@ -37,7 +39,7 @@ tasks:
 
   - id: "TASK-3.2"
     description: "Add a lightweight shared viewer modal and content-loading helper for Session Inspector activity and files surfaces."
-    status: "pending"
+    status: "completed"
     assigned_to: ["frontend-platform"]
     dependencies: ["TASK-3.1"]
     estimated_effort: "2pt"
@@ -45,7 +47,7 @@ tasks:
 
   - id: "TASK-3.3"
     description: "Apply narrow transcript detail-pane shared viewer behavior only for file-backed or explicit file-content log payloads."
-    status: "pending"
+    status: "completed"
     assigned_to: ["frontend-platform"]
     dependencies: ["TASK-3.2"]
     estimated_effort: "2pt"
@@ -53,7 +55,7 @@ tasks:
 
   - id: "TASK-3.4"
     description: "Add regression tests for the new file-content API and Session Inspector shared-viewer adoption, then run validation."
-    status: "pending"
+    status: "completed"
     assigned_to: ["frontend-platform"]
     dependencies: ["TASK-3.3"]
     estimated_effort: "2pt"

--- a/.claude/progress/shared-content-viewer-standardization-v1/phase-4-progress.md
+++ b/.claude/progress/shared-content-viewer-standardization-v1/phase-4-progress.md
@@ -1,0 +1,93 @@
+---
+type: progress
+schema_version: 2
+doc_type: progress
+prd: "shared-content-viewer-standardization-v1"
+feature_slug: "shared-content-viewer-standardization-v1"
+prd_ref: null
+plan_ref: /docs/project_plans/implementation_plans/enhancements/shared-content-viewer-standardization-v1.md
+phase: 4
+title: "Optional explorer unification with packaged FileTree"
+status: "completed"
+started: "2026-03-19"
+completed: "2026-03-19"
+commit_refs:
+  - "2d0eec6"
+pr_refs: []
+
+overall_progress: 100
+completion_estimate: "completed"
+
+total_tasks: 4
+completed_tasks: 4
+in_progress_tasks: 0
+blocked_tasks: 0
+at_risk_tasks: 0
+
+owners: ["frontend-platform"]
+contributors: ["ai-agents"]
+
+tasks:
+  - id: "TASK-4.1"
+    description: "Validate whether packaged frontmatter support can be reused directly in CCDash document panes."
+    status: "completed"
+    assigned_to: ["frontend-platform"]
+    dependencies: ["phase-3-complete"]
+    estimated_effort: "1pt"
+    priority: "high"
+
+  - id: "TASK-4.2"
+    description: "Wire explicit document frontmatter metadata through UnifiedContentViewer and preserve frontmatter when body-only edits are saved."
+    status: "completed"
+    assigned_to: ["frontend-platform"]
+    dependencies: ["TASK-4.1"]
+    estimated_effort: "2pt"
+    priority: "high"
+
+  - id: "TASK-4.3"
+    description: "Replace the PlanCatalog custom folder explorer with packaged FileTree via a document-tree adapter."
+    status: "completed"
+    assigned_to: ["frontend-platform"]
+    dependencies: ["TASK-4.1"]
+    estimated_effort: "2pt"
+    priority: "medium"
+
+  - id: "TASK-4.4"
+    description: "Add regression coverage for frontmatter rendering and document-tree adaptation, then run focused validation."
+    status: "completed"
+    assigned_to: ["frontend-platform"]
+    dependencies: ["TASK-4.2", "TASK-4.3"]
+    estimated_effort: "1pt"
+    priority: "high"
+
+parallelization:
+  batch_1: ["TASK-4.1"]
+  batch_2: ["TASK-4.2", "TASK-4.3"]
+  batch_3: ["TASK-4.4"]
+  critical_path: ["TASK-4.1", "TASK-4.2", "TASK-4.4"]
+  estimated_total_time: "6pt / ~1 day"
+
+blockers: []
+
+success_criteria:
+  - "Document-backed panes show parsed frontmatter even when CCDash stores only the markdown body in PlanDocument.content."
+  - "Saving a plan document from CCDash preserves the existing YAML frontmatter block when the editor submits body-only markdown."
+  - "PlanCatalog folder mode uses packaged FileTree without losing file selection behavior."
+  - "Targeted frontend and backend regression coverage validates the new viewer and adapter paths."
+
+files_modified:
+  - "backend/routers/api.py"
+  - "backend/tests/test_documents_router.py"
+  - "components/DocumentModal.tsx"
+  - "components/PlanCatalog.tsx"
+  - "components/content/UnifiedContentViewer.tsx"
+  - "components/content/__tests__/UnifiedContentViewer.test.tsx"
+  - "lib/contentViewer.ts"
+  - "lib/__tests__/contentViewer.test.ts"
+  - "lib/documentFileTree.ts"
+  - "lib/__tests__/documentFileTree.test.ts"
+---
+
+# shared-content-viewer-standardization-v1 - Phase 4
+
+Packaged frontmatter rendering is available in `@miethe/ui`, but CCDash had to pass parsed document frontmatter explicitly because backend document parsing stores body content separately from the YAML block.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Visual previews of CCDash across its core surfaces. Screenshots are captured aga
 ### Session Inspector & Forensics
 
 - **3-Pane Transcript**: Fluid layout with log list, detail view, and metadata sidebar
+- Shared Content Viewer: Long-form prompts, markdown-like detail payloads, and raw file-backed session rows open in the standardized viewer shell
 - **Deep Forensics**: Queue pressure, resource footprint, subagent topology, and hook signals
 - Session Analytics: Token timeline, model allocation, session block insights, and master timeline
 - Artifact Cards: Skills, commands, agents, hooks, tasks, and test-run artifacts with source correlation
@@ -92,6 +93,7 @@ Visual previews of CCDash across its core surfaces. Screenshots are captured aga
 - **Card Grid View**: Visual overview of PRDs, RFCs, and architecture docs in scannable card format
 - Folder Explorer: 3-pane IDE-style file explorer for navigating documentation hierarchies
 - Document Modal: Tabbed modal with Summary, Delivery, Relationships, Content, and Timeline views
+- Shared Viewer Rendering: Documents, plans, reports, and task sources share the same formatted content shell with frontmatter-aware markdown rendering
 - Inline Document Editing: Edit plan documents in-modal with local save and GitHub write-back support
 
 ### Codebase Explorer
@@ -328,9 +330,11 @@ Markdown documentation with typed identity/classification metadata, canonical de
 |-------|---------|
 | [`docs/setup-user-guide.md`](docs/setup-user-guide.md) | Setup, troubleshooting, and deployment |
 | [`docs/testing-user-guide.md`](docs/testing-user-guide.md) | Test configuration and ingestion flow |
+| [`docs/shared-content-viewer-user-guide.md`](docs/shared-content-viewer-user-guide.md) | End-user content rendering behavior across documents, task sources, and sessions |
 | [`docs/execution-workbench-user-guide.md`](docs/execution-workbench-user-guide.md) | End-user execution workflow |
 | [`docs/agentic-sdlc-intelligence-user-guide.md`](docs/agentic-sdlc-intelligence-user-guide.md) | Workflow intelligence and recommended-stack usage |
 | [`docs/session-usage-attribution-user-guide.md`](docs/session-usage-attribution-user-guide.md) | Attribution semantics and interpretation |
+| [`docs/shared-content-viewer-developer-reference.md`](docs/shared-content-viewer-developer-reference.md) | Wrapper architecture, heuristics, styling, and backend support for shared viewer flows |
 | [`docs/agentic-sdlc-intelligence-developer-reference.md`](docs/agentic-sdlc-intelligence-developer-reference.md) | Implementation details and rollout commands |
 | [`docs/session-usage-attribution-developer-reference.md`](docs/session-usage-attribution-developer-reference.md) | Attribution contracts, API details, and rollout controls |
 | [`docs/sync-observability-and-audit.md`](docs/sync-observability-and-audit.md) | Sync and rebuild operation behavior |

--- a/backend/routers/api.py
+++ b/backend/routers/api.py
@@ -83,6 +83,34 @@ def _safe_json_list(raw: str | list | None) -> list:
         return []
 
 
+def _extract_frontmatter_block(text: str) -> tuple[str, str]:
+    match = re.match(r"^(---\s*\n.*?\n---\s*\n?)(.*)$", text, re.DOTALL)
+    if not match:
+        return "", text
+    return match.group(1), match.group(2)
+
+
+def _preserve_document_frontmatter(
+    source_file: Path,
+    content: str,
+    *,
+    has_frontmatter: bool,
+) -> str:
+    if not has_frontmatter or not content or _extract_frontmatter_block(content)[0]:
+        return content
+
+    try:
+        existing_content = source_file.read_text(encoding="utf-8")
+    except OSError:
+        return content
+
+    frontmatter_block, _ = _extract_frontmatter_block(existing_content)
+    if not frontmatter_block:
+        return content
+
+    return f"{frontmatter_block}{content}"
+
+
 def _usage_ratio(numerator: Any, denominator: Any) -> float:
     try:
         num = max(0.0, float(numerator or 0))
@@ -1637,7 +1665,12 @@ async def update_document(doc_id: str, req: DocumentUpdateRequest, request: Requ
     except ValueError as exc:
         raise HTTPException(status_code=400, detail="The document source file is outside the resolved plan-docs path.") from exc
 
-    content = str(req.content or "").replace("\r\n", "\n")
+    request_content = str(req.content or "").replace("\r\n", "\n")
+    content = _preserve_document_frontmatter(
+        source_file,
+        request_content,
+        has_frontmatter=bool(row.get("has_frontmatter")),
+    )
     write_mode: Literal["local", "github_repo"] = "local"
     commit_hash = ""
     message = "Document saved locally."
@@ -1695,8 +1728,8 @@ async def update_document(doc_id: str, req: DocumentUpdateRequest, request: Requ
         if refreshed_row
         else _map_document_row_to_model({**dict(row), "content": content}, include_content=True, link_counts=None)
     )
-    if document.content != content:
-        document = document.model_copy(update={"content": content})
+    if document.content != request_content:
+        document = document.model_copy(update={"content": request_content})
 
     return DocumentUpdateResponse(
         document=document,

--- a/backend/routers/codebase.py
+++ b/backend/routers/codebase.py
@@ -72,6 +72,22 @@ async def get_codebase_files(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
+@codebase_router.get("/file-content")
+async def get_codebase_file_content(
+    path: str = Query("", description="Project-relative file path"),
+):
+    project = _get_active_project()
+    project_root = project_manager.get_project_root(project)
+    db = await connection.get_connection()
+    service = CodebaseExplorerService(db, project, project_root=project_root)
+    try:
+        return await service.get_file_content(file_path=path)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
 @codebase_router.get("/files/{file_path:path}")
 async def get_codebase_file_detail(
     file_path: str,

--- a/backend/routers/codebase.py
+++ b/backend/routers/codebase.py
@@ -74,7 +74,7 @@ async def get_codebase_files(
 
 @codebase_router.get("/file-content")
 async def get_codebase_file_content(
-    path: str = Query("", description="Project-relative file path"),
+    path: str = Query("", description="Project-relative or absolute filesystem file path"),
 ):
     project = _get_active_project()
     project_root = project_manager.get_project_root(project)

--- a/backend/services/codebase_explorer.py
+++ b/backend/services/codebase_explorer.py
@@ -19,6 +19,7 @@ except Exception:  # pragma: no cover - fallback path
 
 BUILTIN_EXCLUDES = (".git/", "node_modules/", "dist/", "coverage/", ".venv/")
 CACHE_TTL_SECONDS = 30.0
+MAX_FILE_CONTENT_BYTES = 256 * 1024
 ACTION_WEIGHTS = {
     "create": 1.00,
     "update": 0.80,
@@ -615,6 +616,28 @@ class CodebaseExplorerService:
             "features": summary.features,
             "documents": document_items,
             "activity": activity_entries,
+        }
+
+    async def get_file_content(self, file_path: str) -> dict[str, Any]:
+        rel_path, absolute_path = _resolve_safe_path(self.project_root, file_path)
+        if not absolute_path.exists() or not absolute_path.is_file():
+            raise FileNotFoundError(f"File not found: {rel_path}")
+
+        raw = absolute_path.read_bytes()
+        if b"\x00" in raw:
+            raise ValueError("Binary files are not supported by the shared content viewer")
+
+        original_size = len(raw)
+        truncated = original_size > MAX_FILE_CONTENT_BYTES
+        visible = raw[:MAX_FILE_CONTENT_BYTES]
+
+        return {
+            "filePath": rel_path,
+            "absolutePath": str(absolute_path),
+            "content": visible.decode("utf-8", errors="replace"),
+            "sizeBytes": original_size,
+            "truncated": truncated,
+            "originalSize": original_size if truncated else None,
         }
 
     async def _get_snapshot(self, *, include_untouched: bool = False) -> Snapshot:

--- a/backend/services/codebase_explorer.py
+++ b/backend/services/codebase_explorer.py
@@ -120,6 +120,24 @@ def _resolve_safe_path(project_root: Path, requested_path: str) -> tuple[str, Pa
     return rel, candidate
 
 
+def _resolve_file_content_path(project_root: Path, requested_path: str) -> tuple[str, Path]:
+    text = str(requested_path or "").strip()
+    if not text:
+        raise ValueError("File path cannot be empty")
+
+    candidate = Path(text).expanduser()
+    if candidate.is_absolute():
+        resolved = candidate.resolve(strict=False)
+        root = project_root.resolve(strict=False)
+        try:
+            rel = resolved.relative_to(root)
+            return _normalize_rel_path(str(rel)), resolved
+        except ValueError:
+            return str(resolved).replace("\\", "/"), resolved
+
+    return _resolve_safe_path(project_root, text)
+
+
 def _normalize_action(action: str | None, source_tool_name: str | None = None) -> str:
     normalized = (action or "").strip().lower()
     if normalized == "read":
@@ -619,7 +637,7 @@ class CodebaseExplorerService:
         }
 
     async def get_file_content(self, file_path: str) -> dict[str, Any]:
-        rel_path, absolute_path = _resolve_safe_path(self.project_root, file_path)
+        rel_path, absolute_path = _resolve_file_content_path(self.project_root, file_path)
         if not absolute_path.exists() or not absolute_path.is_file():
             raise FileNotFoundError(f"File not found: {rel_path}")
 

--- a/backend/tests/test_codebase_router.py
+++ b/backend/tests/test_codebase_router.py
@@ -336,6 +336,35 @@ class CodebaseRouterTests(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(payload["truncated"])
         self.assertIsNone(payload["originalSize"])
 
+    async def test_file_content_accepts_absolute_project_path(self) -> None:
+        absolute_path = (self.project_root / "src" / "app.ts").resolve(strict=False)
+
+        with (
+            patch.object(codebase_router.project_manager, "get_active_project", return_value=self.project),
+            patch.object(codebase_router.connection, "get_connection", return_value=self.db),
+        ):
+            payload = await codebase_router.get_codebase_file_content(str(absolute_path))
+
+        self.assertEqual(payload["filePath"], "src/app.ts")
+        self.assertEqual(payload["absolutePath"], str(absolute_path))
+        self.assertIn("export const app = 1;", payload["content"])
+
+    async def test_file_content_accepts_absolute_external_path(self) -> None:
+        with tempfile.TemporaryDirectory() as external_tmpdir:
+            external_dir = Path(external_tmpdir)
+            external_path = (external_dir / "shared.txt").resolve(strict=False)
+            external_path.write_text("shared viewer content\n", encoding="utf-8")
+
+            with (
+                patch.object(codebase_router.project_manager, "get_active_project", return_value=self.project),
+                patch.object(codebase_router.connection, "get_connection", return_value=self.db),
+            ):
+                payload = await codebase_router.get_codebase_file_content(str(external_path))
+
+            self.assertEqual(payload["filePath"], str(external_path))
+            self.assertEqual(payload["absolutePath"], str(external_path))
+            self.assertIn("shared viewer content", payload["content"])
+
     async def test_file_content_path_traversal_rejected(self) -> None:
         with (
             patch.object(codebase_router.project_manager, "get_active_project", return_value=self.project),

--- a/backend/tests/test_codebase_router.py
+++ b/backend/tests/test_codebase_router.py
@@ -323,6 +323,29 @@ class CodebaseRouterTests(unittest.IsolatedAsyncioTestCase):
         self.assertGreaterEqual(len(detail["activity"]), 1)
         self.assertTrue(any(entry.get("artifactCount", 0) > 0 for entry in detail["activity"]))
 
+    async def test_file_content_returns_text_payload(self) -> None:
+        with (
+            patch.object(codebase_router.project_manager, "get_active_project", return_value=self.project),
+            patch.object(codebase_router.connection, "get_connection", return_value=self.db),
+        ):
+            payload = await codebase_router.get_codebase_file_content("src/app.ts")
+
+        self.assertEqual(payload["filePath"], "src/app.ts")
+        self.assertIn("export const app = 1;", payload["content"])
+        self.assertEqual(payload["sizeBytes"], len("export const app = 1;\n".encode("utf-8")))
+        self.assertFalse(payload["truncated"])
+        self.assertIsNone(payload["originalSize"])
+
+    async def test_file_content_path_traversal_rejected(self) -> None:
+        with (
+            patch.object(codebase_router.project_manager, "get_active_project", return_value=self.project),
+            patch.object(codebase_router.connection, "get_connection", return_value=self.db),
+        ):
+            with self.assertRaises(HTTPException) as ctx:
+                await codebase_router.get_codebase_file_content("../secret.txt")
+
+        self.assertEqual(ctx.exception.status_code, 400)
+
     async def test_involvement_levels_follow_thresholds(self) -> None:
         with (
             patch.object(codebase_router.project_manager, "get_active_project", return_value=self.project),

--- a/backend/tests/test_documents_router.py
+++ b/backend/tests/test_documents_router.py
@@ -184,6 +184,42 @@ class DocumentRouterWriteTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.document.content, "# Updated\n")
         sync_engine.sync_changed_files.assert_awaited()
 
+    async def test_update_document_preserves_existing_frontmatter_when_saving_body_only(self) -> None:
+        project = self._local_project()
+        bundle = self._bundle(project)
+        sync_engine = AsyncMock()
+        self.plan_file.write_text("---\ntitle: Plan\nstatus: draft\n---\n# Initial\n", encoding="utf-8")
+        await self.db.execute(
+            """
+            UPDATE documents
+            SET has_frontmatter = 1,
+                frontmatter_type = ?,
+                frontmatter_json = ?,
+                content = ?
+            WHERE id = ?
+            """,
+            ("yaml", '{"title":"Plan","status":"draft"}', "# Initial\n", "DOC-plan"),
+        )
+        await self.db.commit()
+
+        with (
+            patch.object(api_router.connection, "get_connection", new=AsyncMock(return_value=self.db)),
+            patch.object(api_router.project_manager, "get_active_project", return_value=project),
+            patch.object(api_router.project_manager, "get_active_path_bundle", return_value=bundle),
+        ):
+            response = await api_router.update_document(
+                "DOC-plan",
+                api_router.DocumentUpdateRequest(content="# Updated\n"),
+                _make_request(sync_engine),
+            )
+
+        self.assertEqual(
+            self.plan_file.read_text(encoding="utf-8"),
+            "---\ntitle: Plan\nstatus: draft\n---\n# Updated\n",
+        )
+        self.assertEqual(response.document.content, "# Updated\n")
+        sync_engine.sync_changed_files.assert_awaited()
+
     async def test_update_document_rejects_repo_write_when_github_disabled(self) -> None:
         project = self._github_project()
         bundle = self._bundle(project)

--- a/components/DocumentModal.tsx
+++ b/components/DocumentModal.tsx
@@ -15,6 +15,7 @@ import { useNavigate } from 'react-router-dom';
 import { getFeatureStatusStyle } from './featureStatus';
 import { UnifiedContentViewer } from './content/UnifiedContentViewer';
 import { updateDocument as saveDocument } from '../services/documents';
+import { resolveContentViewerFrontmatter } from '../lib/contentViewer';
 
 export const getFileContent = (doc: PlanDocument): string => {
    if (doc.content) return doc.content;
@@ -752,6 +753,7 @@ export const DocumentModal = ({
                         <UnifiedContentViewer
                            path={doc.canonicalPath || doc.filePath || null}
                            content={currentContent}
+                           frontmatter={resolveContentViewerFrontmatter(doc.frontmatter as Record<string, unknown> | null | undefined)}
                            readOnly={!canEditDocument}
                            isEditing={isEditing}
                            editedContent={draftContent}

--- a/components/DocumentModal.tsx
+++ b/components/DocumentModal.tsx
@@ -12,9 +12,8 @@ import {
 } from 'lucide-react';
 import { useData } from '../contexts/DataContext';
 import { useNavigate } from 'react-router-dom';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
 import { getFeatureStatusStyle } from './featureStatus';
+import { UnifiedContentViewer } from './content/UnifiedContentViewer';
 import { updateDocument as saveDocument } from '../services/documents';
 
 export const getFileContent = (doc: PlanDocument): string => {
@@ -237,7 +236,6 @@ export const DocumentModal = ({
    const [isEditing, setIsEditing] = React.useState(false);
    const [draftContent, setDraftContent] = React.useState(() => getFileContent(initialDoc));
    const [commitMessage, setCommitMessage] = React.useState('');
-   const [saveBusy, setSaveBusy] = React.useState(false);
    const [saveError, setSaveError] = React.useState<string | null>(null);
    const [saveMessage, setSaveMessage] = React.useState<string | null>(null);
 
@@ -288,7 +286,6 @@ export const DocumentModal = ({
    const doc = normalizeDoc(fullDoc || initialDoc, initialDoc);
    const canEditDocument = doc.rootKind === 'project_plans';
    const currentContent = getFileContent(doc);
-   const hasUnsavedChanges = draftContent !== currentContent;
    const isProgressDoc = doc.rootKind === 'progress' || (doc.docSubtype || '').startsWith('progress_');
 
    React.useEffect(() => {
@@ -312,19 +309,17 @@ export const DocumentModal = ({
    }, [currentContent]);
 
    const handleCancelEdit = React.useCallback(() => {
-      setDraftContent(currentContent);
       setCommitMessage('');
       setSaveError(null);
       setIsEditing(false);
-   }, [currentContent]);
+   }, []);
 
-   const handleSave = React.useCallback(async () => {
-      setSaveBusy(true);
+   const handleSave = React.useCallback(async (content: string) => {
       setSaveError(null);
       setSaveMessage(null);
       try {
          const response = await saveDocument(doc.id, {
-            content: draftContent,
+            content,
             commitMessage,
          });
          const nextDoc = normalizeDoc(response.document, doc);
@@ -338,10 +333,9 @@ export const DocumentModal = ({
          await refreshDocuments();
       } catch (error: any) {
          setSaveError(error?.message || 'Failed to save document');
-      } finally {
-         setSaveBusy(false);
+         throw error;
       }
-   }, [commitMessage, doc, draftContent, refreshDocuments]);
+   }, [commitMessage, doc, refreshDocuments]);
    const linkedFeatures = React.useMemo(() => {
       const featureById = new Map<string, { id: string; name: string; status: string; category: string }>();
       features.forEach(feature => {
@@ -511,35 +505,6 @@ export const DocumentModal = ({
                   </div>
                </div>
                <div className="flex items-center gap-2">
-                  {canEditDocument && !isEditing && (
-                     <button
-                        type="button"
-                        onClick={handleStartEdit}
-                        className="rounded-lg border border-indigo-500/30 bg-indigo-500/10 px-3 py-2 text-xs font-semibold text-indigo-200 hover:bg-indigo-500/20"
-                     >
-                        Edit Markdown
-                     </button>
-                  )}
-                  {canEditDocument && isEditing && (
-                     <>
-                        <button
-                           type="button"
-                           onClick={handleCancelEdit}
-                           disabled={saveBusy}
-                           className="rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-xs font-semibold text-slate-200 hover:border-slate-600 disabled:opacity-50"
-                        >
-                           Cancel
-                        </button>
-                        <button
-                           type="button"
-                           onClick={() => { void handleSave(); }}
-                           disabled={saveBusy || !hasUnsavedChanges}
-                           className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-xs font-semibold text-emerald-200 hover:bg-emerald-500/20 disabled:opacity-50"
-                        >
-                           {saveBusy ? 'Saving...' : 'Save'}
-                        </button>
-                     </>
-                  )}
                   <button onClick={onClose} className="text-slate-500 hover:text-slate-200 transition-colors p-1 hover:bg-slate-800 rounded">
                      <X size={24} />
                   </button>
@@ -771,8 +736,8 @@ export const DocumentModal = ({
 
                {activeTab === 'content' && (
                   <div className="bg-slate-900 border border-slate-800 rounded-lg p-6">
-                     {isEditing ? (
-                        <div className="space-y-4">
+                     <div className="space-y-4">
+                        {canEditDocument && isEditing && (
                            <label className="block">
                               <span className="block text-xs uppercase tracking-wide text-slate-500 mb-2">Commit Message (optional)</span>
                               <input
@@ -783,19 +748,20 @@ export const DocumentModal = ({
                                  placeholder={`ccdash: update ${doc.title}`}
                               />
                            </label>
-                           <textarea
-                              value={draftContent}
-                              onChange={event => setDraftContent(event.target.value)}
-                              className="h-[52vh] w-full resize-y rounded-lg border border-slate-700 bg-slate-950 p-3 font-mono text-[13px] text-slate-200 focus:outline-none focus:border-indigo-500"
-                           />
-                        </div>
-                     ) : (
-                        <div className="prose prose-invert prose-sm max-w-none [&_h1]:text-slate-100 [&_h2]:text-slate-200 [&_h3]:text-slate-300 [&_p]:text-slate-400 [&_li]:text-slate-400 [&_code]:bg-slate-800 [&_code]:text-indigo-300 [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded [&_pre]:bg-slate-900 [&_pre]:border [&_pre]:border-slate-800 [&_a]:text-indigo-400 [&_a:hover]:text-indigo-300 [&_blockquote]:border-l-indigo-500 [&_blockquote]:text-slate-400">
-                           <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                              {currentContent}
-                           </ReactMarkdown>
-                        </div>
-                     )}
+                        )}
+                        <UnifiedContentViewer
+                           path={doc.canonicalPath || doc.filePath || null}
+                           content={currentContent}
+                           readOnly={!canEditDocument}
+                           isEditing={isEditing}
+                           editedContent={draftContent}
+                           onEditStart={canEditDocument && !isEditing ? handleStartEdit : undefined}
+                           onEditChange={setDraftContent}
+                           onSave={canEditDocument && isEditing ? handleSave : undefined}
+                           onCancel={canEditDocument && isEditing ? handleCancelEdit : undefined}
+                           className="h-[52vh]"
+                        />
+                     </div>
                   </div>
                )}
 

--- a/components/PlanCatalog.tsx
+++ b/components/PlanCatalog.tsx
@@ -4,10 +4,9 @@ import { useData } from '../contexts/DataContext';
 import { PlanDocument } from '../types';
 import { FileText, Folder, LayoutGrid, List, Search, FolderTree, ChevronRight, ChevronDown, User, Maximize2 } from 'lucide-react';
 import { DocumentModal, getFileContent } from './DocumentModal';
+import { UnifiedContentViewer } from './content/UnifiedContentViewer';
 import { getFeatureStatusStyle } from './featureStatus';
 import { SidebarFiltersPortal, SidebarFiltersSection } from './SidebarFilters';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
 
 // --- Types ---
 type ViewMode = 'card' | 'list' | 'folder';
@@ -895,12 +894,13 @@ export const PlanCatalog: React.FC = () => {
                                             <Maximize2 size={12} /> Expand
                                         </button>
                                     </div>
-                                    <div className="flex-1 overflow-y-auto p-6">
-                                        <div className="prose prose-invert prose-sm max-w-none [&_h1]:text-slate-100 [&_h2]:text-slate-200 [&_h3]:text-slate-300 [&_p]:text-slate-400 [&_li]:text-slate-400 [&_code]:bg-slate-800 [&_code]:text-indigo-300 [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded [&_pre]:bg-slate-900 [&_pre]:border [&_pre]:border-slate-800 [&_a]:text-indigo-400 [&_a:hover]:text-indigo-300 [&_blockquote]:border-l-indigo-500 [&_blockquote]:text-slate-400 [&_table]:border-collapse [&_th]:bg-slate-800 [&_th]:text-slate-300 [&_th]:px-3 [&_th]:py-2 [&_td]:px-3 [&_td]:py-2 [&_td]:border-t [&_td]:border-slate-800">
-                                            <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                                                {getFileContent(activeDoc)}
-                                            </ReactMarkdown>
-                                        </div>
+                                    <div className="flex-1 overflow-hidden p-4">
+                                        <UnifiedContentViewer
+                                            path={activeDoc.canonicalPath || activeDoc.filePath || null}
+                                            content={getFileContent(activeDoc)}
+                                            readOnly
+                                            className="h-full"
+                                        />
                                     </div>
                                 </>
                             ) : (

--- a/components/PlanCatalog.tsx
+++ b/components/PlanCatalog.tsx
@@ -1,12 +1,15 @@
 import React, { useState, useMemo, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import { FileTree } from '@miethe/ui/content-viewer';
 import { useData } from '../contexts/DataContext';
 import { PlanDocument } from '../types';
-import { FileText, Folder, LayoutGrid, List, Search, FolderTree, ChevronRight, ChevronDown, User, Maximize2 } from 'lucide-react';
+import { FileText, LayoutGrid, List, Search, FolderTree, ChevronRight, ChevronDown, User, Maximize2 } from 'lucide-react';
 import { DocumentModal, getFileContent } from './DocumentModal';
 import { UnifiedContentViewer } from './content/UnifiedContentViewer';
 import { getFeatureStatusStyle } from './featureStatus';
 import { SidebarFiltersPortal, SidebarFiltersSection } from './SidebarFilters';
+import { resolveContentViewerFrontmatter } from '../lib/contentViewer';
+import { buildDocumentFileTree } from '../lib/documentFileTree';
 
 // --- Types ---
 type ViewMode = 'card' | 'list' | 'folder';
@@ -203,57 +206,6 @@ const getSecondaryMetadataLine = (doc: PlanDocument): string => {
     return 'Supporting document';
 };
 
-const FolderTreeItem = ({
-    name,
-    path,
-    type,
-    children,
-    level = 0,
-    onSelect,
-    activePath
-}: {
-    name: string;
-    path: string;
-    type: 'file' | 'folder';
-    children?: any[];
-    level?: number;
-    onSelect: (path: string) => void;
-    activePath: string | null;
-}) => {
-    const [isOpen, setIsOpen] = useState(true);
-    const isSelected = activePath === path;
-
-    return (
-        <div>
-            <div
-                className={`flex items-center gap-2 px-2 py-1.5 cursor-pointer text-sm hover:bg-slate-800 transition-colors ${isSelected ? 'bg-indigo-500/20 text-indigo-300' : 'text-slate-400'}`}
-                style={{ paddingLeft: `${level * 12 + 8}px` }}
-                onClick={() => {
-                    if (type === 'folder') setIsOpen(!isOpen);
-                    else onSelect(path);
-                }}
-            >
-                {type === 'folder' ? (
-                    isOpen ? <ChevronDown size={14} className="text-slate-500" /> : <ChevronRight size={14} className="text-slate-500" />
-                ) : (
-                    <span className="w-3.5"></span>
-                )}
-                {type === 'folder' ? <Folder size={16} className="fill-slate-700 text-slate-500" /> : <FileText size={16} className="text-slate-500" />}
-                <span className="truncate">{name}</span>
-            </div>
-            {isOpen && children && children.map((child: any) => (
-                <FolderTreeItem
-                    key={child.path}
-                    {...child}
-                    level={level + 1}
-                    onSelect={onSelect}
-                    activePath={activePath}
-                />
-            ))}
-        </div>
-    );
-};
-
 // --- Main Page Component ---
 
 export const PlanCatalog: React.FC = () => {
@@ -431,34 +383,7 @@ export const PlanCatalog: React.FC = () => {
     ]);
 
     // Tree Building Logic
-    const fileTree = useMemo(() => {
-        const tree: any[] = [];
-        filteredDocs.forEach(doc => {
-            const parts = doc.filePath.split('/');
-            let currentLevel = tree;
-
-            parts.forEach((part, idx) => {
-                const isFile = idx === parts.length - 1;
-                const path = parts.slice(0, idx + 1).join('/');
-                const existing = currentLevel.find(n => n.name === part);
-
-                if (existing) {
-                    currentLevel = existing.children;
-                } else {
-                    const newNode = {
-                        name: part,
-                        path: path,
-                        type: isFile ? 'file' : 'folder',
-                        children: isFile ? undefined : [],
-                        doc: isFile ? doc : undefined
-                    };
-                    currentLevel.push(newNode);
-                    currentLevel = newNode.children || [];
-                }
-            });
-        });
-        return tree;
-    }, [filteredDocs]);
+    const fileTree = useMemo(() => buildDocumentFileTree(filteredDocs), [filteredDocs]);
 
     // Handle tree Selection
     const activeDoc = activeFilePath ? filteredDocs.find(d => d.filePath === activeFilePath) : null;
@@ -871,10 +796,15 @@ export const PlanCatalog: React.FC = () => {
                         {/* Left Pane: Tree */}
                         <div className="w-1/4 border-r border-slate-800 bg-slate-950 flex flex-col">
                             <div className="p-3 border-b border-slate-800 text-xs font-bold text-slate-500 uppercase">Explorer</div>
-                            <div className="flex-1 overflow-y-auto p-2">
-                                {fileTree.map(node => (
-                                    <FolderTreeItem key={node.path} {...node} onSelect={setActiveFilePath} activePath={activeFilePath} />
-                                ))}
+                            <div className="flex-1 overflow-hidden p-2">
+                                <FileTree
+                                    entityId="plan-catalog"
+                                    files={fileTree}
+                                    selectedPath={activeFilePath}
+                                    onSelect={setActiveFilePath}
+                                    readOnly
+                                    ariaLabel="Document explorer"
+                                />
                             </div>
                         </div>
 
@@ -898,6 +828,7 @@ export const PlanCatalog: React.FC = () => {
                                         <UnifiedContentViewer
                                             path={activeDoc.canonicalPath || activeDoc.filePath || null}
                                             content={getFileContent(activeDoc)}
+                                            frontmatter={resolveContentViewerFrontmatter(activeDoc.frontmatter as Record<string, unknown> | null | undefined)}
                                             readOnly
                                             className="h-full"
                                         />

--- a/components/ProjectBoard.tsx
+++ b/components/ProjectBoard.tsx
@@ -8,6 +8,7 @@ import { trackExecutionEvent } from '../services/execution';
 import { getFeatureHealth } from '../services/testVisualizer';
 import { SessionCard, SessionCardDetailSection, deriveSessionCardTitle } from './SessionCard';
 import { DocumentModal } from './DocumentModal';
+import { UnifiedContentViewer } from './content/UnifiedContentViewer';
 import { SidebarFiltersPortal, SidebarFiltersSection } from './SidebarFilters';
 import { FeatureModalTestStatus } from './TestVisualizer/FeatureModalTestStatus';
 import {
@@ -1156,7 +1157,7 @@ const TaskSourceDialog = ({ task, onClose }: { task: ProjectTask; onClose: () =>
           </button>
         </div>
         <div className="flex-1 overflow-y-auto p-6 bg-slate-950/30">
-          {loading && (
+        {loading && (
             <div className="flex items-center justify-center h-full text-slate-500">
               <RefreshCw size={20} className="animate-spin mr-2" /> Loading source file…
             </div>
@@ -1167,8 +1168,13 @@ const TaskSourceDialog = ({ task, onClose }: { task: ProjectTask; onClose: () =>
               <p className="text-sm">{error}</p>
             </div>
           )}
-          {content && (
-            <pre className="text-sm text-slate-300 font-mono whitespace-pre-wrap leading-relaxed">{content}</pre>
+          {content !== null && !loading && !error && (
+            <UnifiedContentViewer
+              path={task.sourceFile || null}
+              content={content}
+              readOnly
+              className="h-full"
+            />
           )}
         </div>
       </div>

--- a/components/SessionInspector.tsx
+++ b/components/SessionInspector.tsx
@@ -19,7 +19,7 @@ import { TranscriptMappedMessageCard, isMappedTranscriptMessageKind, mappedAccen
 import { TypingIndicator, getMotionPreset, useAnimatedListDiff, useReducedMotionPreference, useSmartScrollAnchor } from './animations';
 import { Badge, ModelBadge, StableBadge } from './ui/badge';
 import { formatModelDisplayName } from '../lib/modelIdentity';
-import { getInlineContentViewerPayload } from '../lib/sessionContentViewer';
+import { getInlineContentViewerPayload, getTranscriptContentViewerPayload } from '../lib/sessionContentViewer';
 import { formatPercent, formatTokenCount, resolveTokenMetrics } from '../lib/tokenMetrics';
 import { contextSummaryLabel, costSummaryLabel, formatContextMeasurementSource, resolveDisplayCost } from '../lib/sessionSemantics';
 import { buildSessionBlockInsights } from '../lib/sessionBlockInsights';
@@ -1589,6 +1589,11 @@ const DetailPane: React.FC<{
         readToolDetails?.filePath,
         log.toolCall?.output,
     );
+    const taskPromptViewerPayload = getTranscriptContentViewerPayload(
+        `${log.id}-task-prompt`,
+        taskToolDetails?.prompt || null,
+    );
+    const transcriptViewerPayload = getTranscriptContentViewerPayload(log.id, log.content);
     const taskDisplayContext = resolveTaskInvocationDisplayContext(log, taskToolDetails, threadSessionDetails, subagentNameBySessionId);
     const detailTitle = (() => {
         if (isMappedTranscriptMessageKind(parsedMessage.kind)) return 'Mapped Transcript Event';
@@ -1825,9 +1830,21 @@ const DetailPane: React.FC<{
                                         )}
                                     </div>
                                     {expandedSections.has('task-full-prompt') && taskToolDetails.prompt && (
-                                        <pre className="mt-3 text-xs font-mono text-slate-300 bg-slate-900/60 p-3 rounded border border-slate-800 whitespace-pre-wrap break-words max-h-96 overflow-y-auto animate-in slide-in-from-top-1 duration-200">
-                                            {taskToolDetails.prompt}
-                                        </pre>
+                                        <div className="mt-3 max-h-96 animate-in slide-in-from-top-1 duration-200">
+                                            {taskPromptViewerPayload ? (
+                                                <UnifiedContentViewer
+                                                    path={taskPromptViewerPayload.path}
+                                                    content={taskPromptViewerPayload.content}
+                                                    readOnly
+                                                    className="h-full"
+                                                    ariaLabel={`Task prompt: ${taskPromptViewerPayload.path}`}
+                                                />
+                                            ) : (
+                                                <pre className="text-xs font-mono text-slate-300 bg-slate-900/60 p-3 rounded border border-slate-800 whitespace-pre-wrap break-words max-h-96 overflow-y-auto">
+                                                    {taskToolDetails.prompt}
+                                                </pre>
+                                            )}
+                                        </div>
                                     )}
                                     {taskToolDetails.args && (
                                         <div className="mt-4 bg-slate-900/60 border border-slate-800 rounded-lg p-3">
@@ -2238,8 +2255,19 @@ const DetailPane: React.FC<{
                 {/* FALLBACK FOR REGULAR/TYPED MESSAGES */}
                 {log.type !== 'tool' && log.type !== 'subagent' && log.type !== 'skill' && (
                     <>
-                        {renderStructuredMessage()}
-                        {renderRawMessageSection()}
+                        {transcriptViewerPayload ? (
+                            <UnifiedContentViewer
+                                path={transcriptViewerPayload.path}
+                                content={transcriptViewerPayload.content}
+                                readOnly
+                                ariaLabel={`Transcript content: ${transcriptViewerPayload.path}`}
+                            />
+                        ) : (
+                            <>
+                                {renderStructuredMessage()}
+                                {renderRawMessageSection()}
+                            </>
+                        )}
                         {log.linkedSessionId && (
                             <p className="text-[11px] text-indigo-300 font-mono">Linked Thread: {log.linkedSessionId}</p>
                         )}
@@ -2249,23 +2277,34 @@ const DetailPane: React.FC<{
                 {/* SKILLS */}
                 {log.type === 'skill' && log.skillDetails && (
                     <div className="space-y-4">
-                        {isMappedTranscriptMessageKind(parsedMessage.kind) && parsedMessage.mapped && (
-                            <TranscriptMappedMessageCard
-                                message={parsedMessage}
-                                commandArtifactsCount={commandArtifacts.length}
-                                onOpenArtifacts={onOpenArtifacts}
+                        {transcriptViewerPayload ? (
+                            <UnifiedContentViewer
+                                path={transcriptViewerPayload.path}
+                                content={transcriptViewerPayload.content}
+                                readOnly
+                                ariaLabel={`Skill content: ${transcriptViewerPayload.path}`}
                             />
+                        ) : (
+                            <>
+                                {isMappedTranscriptMessageKind(parsedMessage.kind) && parsedMessage.mapped && (
+                                    <TranscriptMappedMessageCard
+                                        message={parsedMessage}
+                                        commandArtifactsCount={commandArtifacts.length}
+                                        onOpenArtifacts={onOpenArtifacts}
+                                    />
+                                )}
+                                <div className="bg-slate-900 border border-slate-800 rounded-xl p-5 shadow-lg">
+                                    <div className="flex items-center gap-2 text-blue-400 font-mono text-sm mb-3">
+                                        <Cpu size={16} /> {log.skillDetails.name}
+                                    </div>
+                                    <p className="text-slate-400 text-xs mb-4 leading-relaxed">{log.skillDetails.description}</p>
+                                    <div className="flex items-center justify-between text-[10px] border-t border-slate-800 pt-3">
+                                        <span className="text-slate-500">Version</span>
+                                        <span className="font-mono text-slate-300">{log.skillDetails.version}</span>
+                                    </div>
+                                </div>
+                            </>
                         )}
-                        <div className="bg-slate-900 border border-slate-800 rounded-xl p-5 shadow-lg">
-                            <div className="flex items-center gap-2 text-blue-400 font-mono text-sm mb-3">
-                                <Cpu size={16} /> {log.skillDetails.name}
-                            </div>
-                            <p className="text-slate-400 text-xs mb-4 leading-relaxed">{log.skillDetails.description}</p>
-                            <div className="flex items-center justify-between text-[10px] border-t border-slate-800 pt-3">
-                                <span className="text-slate-500">Version</span>
-                                <span className="font-mono text-slate-300">{log.skillDetails.version}</span>
-                            </div>
-                        </div>
                     </div>
                 )}
             </div>

--- a/components/SessionInspector.tsx
+++ b/components/SessionInspector.tsx
@@ -7,6 +7,8 @@ import { AgentSession, SessionLog, LogType, SessionArtifact, PlanDocument, Sessi
 import { Clock, Database, Terminal, Search, Edit3, GitCommit, GitBranch, ArrowLeft, Bot, Activity, Archive, PlayCircle, Cpu, Zap, Box, ChevronRight, MessageSquare, Code, ChevronDown, Calendar, BarChart2, PieChart as PieChartIcon, Users, TrendingUp, ShieldAlert, FileText, ExternalLink, Link as LinkIcon, HardDrive, Scroll, Maximize2, X, MoreHorizontal, Layers, RefreshCw, LayoutGrid, TestTube2 } from 'lucide-react';
 import { Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, BarChart, Bar, PieChart, Pie, Cell, Legend, ComposedChart, Line } from 'recharts';
 import { DocumentModal } from './DocumentModal';
+import { UnifiedContentViewer } from './content/UnifiedContentViewer';
+import { ProjectFileViewerModal } from './content/ProjectFileViewerModal';
 import { TranscriptFormattedMessage, TranscriptFormattingMappingRule, parseTranscriptMessage, getReadableTagName } from './sessionTranscriptFormatting';
 import { SessionCard, SessionCardDetailSection, deriveSessionCardTitle } from './SessionCard';
 import { SessionArtifactsView } from './SessionArtifactsView';
@@ -17,6 +19,7 @@ import { TranscriptMappedMessageCard, isMappedTranscriptMessageKind, mappedAccen
 import { TypingIndicator, getMotionPreset, useAnimatedListDiff, useReducedMotionPreference, useSmartScrollAnchor } from './animations';
 import { Badge, ModelBadge, StableBadge } from './ui/badge';
 import { formatModelDisplayName } from '../lib/modelIdentity';
+import { getInlineContentViewerPayload } from '../lib/sessionContentViewer';
 import { formatPercent, formatTokenCount, resolveTokenMetrics } from '../lib/tokenMetrics';
 import { contextSummaryLabel, costSummaryLabel, formatContextMeasurementSource, resolveDisplayCost } from '../lib/sessionSemantics';
 import { buildSessionBlockInsights } from '../lib/sessionBlockInsights';
@@ -1582,6 +1585,10 @@ const DetailPane: React.FC<{
     const testToolDetails = getTestRunDetails(log);
     const readToolDetails = getReadToolDetails(log);
     const grepToolDetails = getGrepToolDetails(log);
+    const inlineContentViewerPayload = getInlineContentViewerPayload(
+        readToolDetails?.filePath,
+        log.toolCall?.output,
+    );
     const taskDisplayContext = resolveTaskInvocationDisplayContext(log, taskToolDetails, threadSessionDetails, subagentNameBySessionId);
     const detailTitle = (() => {
         if (isMappedTranscriptMessageKind(parsedMessage.kind)) return 'Mapped Transcript Event';
@@ -2072,6 +2079,17 @@ const DetailPane: React.FC<{
                                             </pre>
                                         </div>
                                     )}
+                                    {inlineContentViewerPayload && (
+                                        <div className="mt-4">
+                                            <div className="mb-2 text-[10px] text-slate-500 uppercase tracking-wider font-bold">Shared Viewer Preview</div>
+                                            <UnifiedContentViewer
+                                                path={inlineContentViewerPayload.path}
+                                                content={inlineContentViewerPayload.content}
+                                                readOnly
+                                                ariaLabel={`Transcript file content: ${inlineContentViewerPayload.path}`}
+                                            />
+                                        </div>
+                                    )}
                                 </div>
                             )}
 
@@ -2162,7 +2180,7 @@ const DetailPane: React.FC<{
                             </div>
 
                             {/* Output Section */}
-                            {log.toolCall.output && (
+                            {log.toolCall.output && !inlineContentViewerPayload && (
                                 <div className="p-4 bg-slate-900/20">
                                     <button
                                         onClick={() => toggleSection('output')}
@@ -3520,9 +3538,10 @@ const ActivityView: React.FC<{
     threadSessionDetails: Record<string, AgentSession>;
     subagentNameBySessionId: Map<string, string>;
     onOpenDoc: (doc: PlanDocument) => void;
+    onOpenFile: (filePath: string, localPath?: string | null) => void;
     onOpenThread: (sessionId: string) => void;
     highlightedSourceLogId?: string | null;
-}> = ({ session, threadSessions, threadSessionDetails, subagentNameBySessionId, onOpenDoc, onOpenThread, highlightedSourceLogId }) => {
+}> = ({ session, threadSessions, threadSessionDetails, subagentNameBySessionId, onOpenDoc, onOpenFile, onOpenThread, highlightedSourceLogId }) => {
     const { documents, activeProject } = useData();
     const sessionsForActivity = useMemo(
         () => collectThreadDetailSessions(session, threadSessions, threadSessionDetails),
@@ -3656,8 +3675,8 @@ const ActivityView: React.FC<{
         );
     }
 
-    const openRowFile = (row: SessionActivityItem) => {
-        if (!row.filePath || !row.localPath) return;
+    const openRowViewer = (row: SessionActivityItem) => {
+        if (!row.filePath) return;
         if (row.documentId) {
             const doc = documents.find(item => item.id === row.documentId);
             if (doc) {
@@ -3665,6 +3684,11 @@ const ActivityView: React.FC<{
                 return;
             }
         }
+        onOpenFile(row.filePath, row.localPath);
+    };
+
+    const openRowFile = (row: SessionActivityItem) => {
+        if (!row.localPath) return;
         window.location.href = `vscode://file/${encodeURI(row.localPath)}`;
     };
 
@@ -3702,6 +3726,15 @@ const ActivityView: React.FC<{
                         </div>
                         <div className="truncate text-slate-400">{row.threadName || row.sessionId}</div>
                         <div className="flex items-center gap-1 justify-end">
+                            {row.kind === 'file' && row.filePath && (
+                                <button
+                                    onClick={() => openRowViewer(row)}
+                                    className="p-1 rounded text-slate-500 hover:text-indigo-300 hover:bg-indigo-500/10"
+                                    title="Open in shared viewer"
+                                >
+                                    <Maximize2 size={14} />
+                                </button>
+                            )}
                             {row.kind === 'file' && row.localPath && (
                                 <button
                                     onClick={() => openRowFile(row)}
@@ -3755,8 +3788,9 @@ const FilesView: React.FC<{
     threadSessionDetails: Record<string, AgentSession>;
     subagentNameBySessionId: Map<string, string>;
     onOpenDoc: (doc: PlanDocument) => void;
+    onOpenFile: (filePath: string, localPath?: string | null) => void;
     highlightedSourceLogId?: string | null;
-}> = ({ session, threadSessions, threadSessionDetails, subagentNameBySessionId, onOpenDoc, highlightedSourceLogId }) => {
+}> = ({ session, threadSessions, threadSessionDetails, subagentNameBySessionId, onOpenDoc, onOpenFile, highlightedSourceLogId }) => {
     const { documents, activeProject } = useData();
     const sessionsForFiles = useMemo(
         () => collectThreadDetailSessions(session, threadSessions, threadSessionDetails),
@@ -3866,7 +3900,7 @@ const FilesView: React.FC<{
 
     return (
         <div className="bg-slate-900 border border-slate-800 rounded-xl overflow-hidden h-full flex flex-col">
-            <div className="grid grid-cols-[1.2fr_1.1fr_70px_80px_80px_150px_100px_90px] gap-2 px-3 py-2 border-b border-slate-800 bg-slate-950/60 text-[10px] font-semibold uppercase tracking-wider text-slate-500">
+            <div className="grid grid-cols-[1.2fr_1.1fr_70px_80px_80px_150px_100px_110px] gap-2 px-3 py-2 border-b border-slate-800 bg-slate-950/60 text-[10px] font-semibold uppercase tracking-wider text-slate-500">
                 <div>File</div>
                 <div>Path</div>
                 <div>Actions</div>
@@ -3874,13 +3908,13 @@ const FilesView: React.FC<{
                 <div>Sessions</div>
                 <div>Last Touched</div>
                 <div>Net Diff</div>
-                <div>Open</div>
+                <div>Links</div>
             </div>
             <div className="flex-1 overflow-y-auto">
                 {fileRows.map(row => (
                     <div
                         key={row.key}
-                        className={`grid grid-cols-[1.2fr_1.1fr_70px_80px_80px_150px_100px_90px] gap-2 px-3 py-2 border-b border-slate-800/70 text-xs hover:bg-slate-800/30 ${highlightedSourceLogId && row.sourceLogIds.includes(highlightedSourceLogId) ? 'bg-indigo-500/10 border-indigo-500/30' : ''}`}
+                        className={`grid grid-cols-[1.2fr_1.1fr_70px_80px_80px_150px_100px_110px] gap-2 px-3 py-2 border-b border-slate-800/70 text-xs hover:bg-slate-800/30 ${highlightedSourceLogId && row.sourceLogIds.includes(highlightedSourceLogId) ? 'bg-indigo-500/10 border-indigo-500/30' : ''}`}
                     >
                         <div className="truncate text-slate-200 font-medium">{row.fileName}</div>
                         <div className="truncate font-mono text-[11px] text-slate-500">{row.filePath}</div>
@@ -3909,12 +3943,24 @@ const FilesView: React.FC<{
                                             return;
                                         }
                                     }
-                                    window.location.href = `vscode://file/${encodeURI(row.localPath)}`;
+                                    onOpenFile(row.filePath, row.localPath);
                                 }}
                                 className="p-1 rounded text-slate-500 hover:text-indigo-300 hover:bg-indigo-500/10"
+                                title="Open in shared viewer"
                             >
-                                <ExternalLink size={14} />
+                                <Maximize2 size={14} />
                             </button>
+                            {row.localPath && (
+                                <button
+                                    onClick={() => {
+                                        window.location.href = `vscode://file/${encodeURI(row.localPath)}`;
+                                    }}
+                                    className="p-1 rounded text-slate-500 hover:text-indigo-300 hover:bg-indigo-500/10"
+                                    title="Open locally"
+                                >
+                                    <ExternalLink size={14} />
+                                </button>
+                            )}
                         </div>
                     </div>
                 ))}
@@ -7254,6 +7300,7 @@ const SessionDetail: React.FC<{
     const [activeTab, setActiveTab] = useState<SessionInspectorTab>(initialTab);
     const [filterAgent, setFilterAgent] = useState<string | null>(null);
     const [viewingDoc, setViewingDoc] = useState<PlanDocument | null>(null);
+    const [viewingFile, setViewingFile] = useState<{ filePath: string; localPath?: string | null } | null>(null);
     const [threadSessions, setThreadSessions] = useState<AgentSession[]>([]);
     const [threadSessionDetails, setThreadSessionDetails] = useState<Record<string, AgentSession>>({ [session.id]: session });
     const [linkedSourceLogId, setLinkedSourceLogId] = useState<string | null>(null);
@@ -7976,6 +8023,7 @@ const SessionDetail: React.FC<{
                         threadSessionDetails={threadSessionDetails}
                         subagentNameBySessionId={subagentNameBySessionId}
                         onOpenDoc={setViewingDoc}
+                        onOpenFile={(filePath, localPath) => setViewingFile({ filePath, localPath })}
                         onOpenThread={onOpenSession}
                         highlightedSourceLogId={linkedSourceLogId}
                     />
@@ -7987,6 +8035,7 @@ const SessionDetail: React.FC<{
                         threadSessionDetails={threadSessionDetails}
                         subagentNameBySessionId={subagentNameBySessionId}
                         onOpenDoc={setViewingDoc}
+                        onOpenFile={(filePath, localPath) => setViewingFile({ filePath, localPath })}
                         highlightedSourceLogId={linkedSourceLogId}
                     />
                 )}
@@ -8022,6 +8071,13 @@ const SessionDetail: React.FC<{
             </div>
 
             {viewingDoc && <DocumentModal doc={viewingDoc} onClose={() => setViewingDoc(null)} />}
+            {viewingFile && (
+                <ProjectFileViewerModal
+                    filePath={viewingFile.filePath}
+                    localPath={viewingFile.localPath}
+                    onClose={() => setViewingFile(null)}
+                />
+            )}
         </div>
     );
 };

--- a/components/content/ProjectFileViewerModal.tsx
+++ b/components/content/ProjectFileViewerModal.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { ExternalLink, X } from 'lucide-react';
+
+import { UnifiedContentViewer } from './UnifiedContentViewer';
+import { getCodebaseFileContent, type CodebaseFileContentResponse } from '../../services/codebase';
+
+interface ProjectFileViewerModalProps {
+  filePath: string;
+  localPath?: string | null;
+  onClose: () => void;
+}
+
+export const ProjectFileViewerModal: React.FC<ProjectFileViewerModalProps> = ({
+  filePath,
+  localPath,
+  onClose,
+}) => {
+  const [payload, setPayload] = React.useState<CodebaseFileContentResponse | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+  const [isLoading, setIsLoading] = React.useState(true);
+
+  React.useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const next = await getCodebaseFileContent(filePath);
+        if (!cancelled) {
+          setPayload(next);
+        }
+      } catch (loadError: any) {
+        if (!cancelled) {
+          setPayload(null);
+          setError(loadError?.message || 'Failed to load file content');
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [filePath]);
+
+  const handleOpenLocalFile = React.useCallback(() => {
+    if (!localPath) return;
+    window.location.href = `vscode://file/${encodeURI(localPath)}`;
+  }, [localPath]);
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-slate-950/80 backdrop-blur-sm p-4 animate-in fade-in duration-200"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-6xl max-h-[92vh] overflow-hidden rounded-2xl border border-slate-800 bg-slate-900 shadow-2xl flex flex-col"
+        onClick={event => event.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-4 border-b border-slate-800 bg-slate-950 px-5 py-4">
+            <div className="min-w-0">
+            <div className="text-[10px] font-semibold uppercase tracking-[0.2em] text-indigo-300">Shared Viewer</div>
+            <h3 className="mt-1 truncate font-mono text-sm text-slate-100">{filePath}</h3>
+            <div className="mt-1 text-xs text-slate-500">
+              {typeof payload?.sizeBytes === 'number' ? `${payload.sizeBytes.toLocaleString()} bytes` : 'Loading file content'}
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            {localPath && (
+              <button
+                type="button"
+                onClick={handleOpenLocalFile}
+                className="inline-flex items-center gap-2 rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-xs text-slate-300 hover:border-indigo-500/40 hover:text-indigo-200"
+              >
+                <ExternalLink size={14} />
+                Open Locally
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-lg p-2 text-slate-500 hover:bg-slate-800 hover:text-slate-200"
+              aria-label="Close file viewer"
+            >
+              <X size={18} />
+            </button>
+          </div>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-hidden p-5">
+          <UnifiedContentViewer
+            path={payload?.filePath || filePath}
+            content={payload?.content || null}
+            isLoading={isLoading}
+            error={error}
+            readOnly
+            truncationInfo={payload?.truncated ? { truncated: true, originalSize: payload.originalSize ?? payload.sizeBytes } : undefined}
+            ariaLabel={`Project file content: ${filePath}`}
+            className="h-full"
+          />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/components/content/UnifiedContentViewer.tsx
+++ b/components/content/UnifiedContentViewer.tsx
@@ -16,6 +16,7 @@ import {
 export interface UnifiedContentViewerProps {
   path: string | null;
   content: string | null;
+  frontmatter?: Record<string, unknown> | null;
   isLoading?: boolean;
   error?: string | null;
   readOnly?: boolean;
@@ -41,6 +42,7 @@ const formatBytes = (bytes: number): string => {
 export const UnifiedContentViewer = ({
   path,
   content,
+  frontmatter = null,
   isLoading = false,
   error = null,
   readOnly = false,
@@ -59,9 +61,24 @@ export const UnifiedContentViewer = ({
   const resolvedTruncationInfo = buildContentViewerTruncationInfo(truncationInfo);
   const viewerMode = getReadOnlyContentViewerMode(normalizedPath, content);
   const canStartEdit = !resolvedReadOnly && !isEditing && typeof onEditStart === 'function';
+  const contentContainsFrontmatter = Boolean(content && detectFrontmatter(content));
+  const hasExplicitFrontmatter = Boolean(
+    frontmatter
+    && typeof frontmatter === 'object'
+    && !Array.isArray(frontmatter)
+    && Object.keys(frontmatter).length > 0,
+  );
+  const shouldRenderExplicitFrontmatter = hasExplicitFrontmatter && !contentContainsFrontmatter;
 
   const parsedContent = React.useMemo(() => {
-    if (!content || !detectFrontmatter(content)) {
+    if (shouldRenderExplicitFrontmatter) {
+      return {
+        frontmatter,
+        displayContent: content || '',
+      };
+    }
+
+    if (!content || !contentContainsFrontmatter) {
       return {
         frontmatter: null as Record<string, unknown> | null,
         displayContent: content || '',
@@ -73,31 +90,40 @@ export const UnifiedContentViewer = ({
       frontmatter: parsed.frontmatter,
       displayContent: stripFrontmatter(content),
     };
-  }, [content]);
+  }, [content, contentContainsFrontmatter, frontmatter, shouldRenderExplicitFrontmatter]);
 
   if (isEditing) {
     return (
       <div
         className={[
-          'ccdash-content-viewer min-h-0 w-full overflow-hidden rounded-2xl border border-slate-800 bg-slate-950/95 shadow-[0_0_0_1px_rgba(15,23,42,0.25),0_24px_80px_rgba(2,6,23,0.6)]',
+          'ccdash-content-viewer flex min-h-0 w-full flex-col overflow-hidden rounded-2xl border border-slate-800 bg-slate-950/95 shadow-[0_0_0_1px_rgba(15,23,42,0.25),0_24px_80px_rgba(2,6,23,0.6)]',
           className || '',
         ].filter(Boolean).join(' ')}
       >
-        <ContentPane
-          path={normalizedPath}
-          content={content}
-          isLoading={isLoading}
-          error={error}
-          readOnly={resolvedReadOnly}
-          truncationInfo={resolvedTruncationInfo}
-          isEditing={isEditing}
-          editedContent={editedContent}
-          onEditStart={onEditStart}
-          onEditChange={onEditChange}
-          onSave={onSave}
-          onCancel={onCancel}
-          ariaLabel={ariaLabel || (normalizedPath ? `File content: ${normalizedPath}` : 'File content viewer')}
-        />
+        {parsedContent.frontmatter && shouldRenderExplicitFrontmatter && (
+          <FrontmatterDisplay
+            frontmatter={parsedContent.frontmatter}
+            defaultCollapsed
+            className="m-4 mb-0 shrink-0"
+          />
+        )}
+        <div className="min-h-0 flex-1 overflow-hidden">
+          <ContentPane
+            path={normalizedPath}
+            content={content}
+            isLoading={isLoading}
+            error={error}
+            readOnly={resolvedReadOnly}
+            truncationInfo={resolvedTruncationInfo}
+            isEditing={isEditing}
+            editedContent={editedContent}
+            onEditStart={onEditStart}
+            onEditChange={onEditChange}
+            onSave={onSave}
+            onCancel={onCancel}
+            ariaLabel={ariaLabel || (normalizedPath ? `File content: ${normalizedPath}` : 'File content viewer')}
+          />
+        </div>
       </div>
     );
   }

--- a/components/content/UnifiedContentViewer.tsx
+++ b/components/content/UnifiedContentViewer.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { ContentPane, type TruncationInfo } from '@miethe/ui/content-viewer';
-import { getContentViewerMode } from '@/lib/contentViewer';
 import {
   buildContentViewerTruncationInfo,
   isContentViewerEditable,
+  getContentViewerMode,
   normalizeContentViewerPath,
-} from '@/lib/contentViewer';
+} from '../../lib/contentViewer';
 
 export interface UnifiedContentViewerProps {
   path: string | null;

--- a/components/content/UnifiedContentViewer.tsx
+++ b/components/content/UnifiedContentViewer.tsx
@@ -1,9 +1,15 @@
 import React from 'react';
+import { Edit3, ChevronRight, AlertTriangle } from 'lucide-react';
 import { ContentPane, type TruncationInfo } from '@miethe/ui/content-viewer';
+import { FrontmatterDisplay } from '@miethe/ui/display';
+import { detectFrontmatter, parseFrontmatter, stripFrontmatter } from '@miethe/ui/utils';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
 import {
   buildContentViewerTruncationInfo,
+  getReadOnlyContentViewerMode,
   isContentViewerEditable,
-  getContentViewerMode,
   normalizeContentViewerPath,
 } from '../../lib/contentViewer';
 
@@ -24,6 +30,14 @@ export interface UnifiedContentViewerProps {
   className?: string;
 }
 
+const formatBytes = (bytes: number): string => {
+  if (bytes === 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  const power = Math.min(units.length - 1, Math.floor(Math.log(bytes) / Math.log(1024)));
+  const value = bytes / 1024 ** power;
+  return power === 0 ? `${bytes} B` : `${value.toFixed(1)} ${units[power]}`;
+};
+
 export const UnifiedContentViewer = ({
   path,
   content,
@@ -41,35 +55,155 @@ export const UnifiedContentViewer = ({
   className,
 }: UnifiedContentViewerProps) => {
   const normalizedPath = normalizeContentViewerPath(path);
-  const viewerMode = getContentViewerMode(normalizedPath);
   const resolvedReadOnly = readOnly || !isContentViewerEditable(normalizedPath);
   const resolvedTruncationInfo = buildContentViewerTruncationInfo(truncationInfo);
+  const viewerMode = getReadOnlyContentViewerMode(normalizedPath, content);
+  const canStartEdit = !resolvedReadOnly && !isEditing && typeof onEditStart === 'function';
+
+  const parsedContent = React.useMemo(() => {
+    if (!content || !detectFrontmatter(content)) {
+      return {
+        frontmatter: null as Record<string, unknown> | null,
+        displayContent: content || '',
+      };
+    }
+
+    const parsed = parseFrontmatter(content);
+    return {
+      frontmatter: parsed.frontmatter,
+      displayContent: stripFrontmatter(content),
+    };
+  }, [content]);
+
+  if (isEditing) {
+    return (
+      <div
+        className={[
+          'ccdash-content-viewer min-h-0 w-full overflow-hidden rounded-2xl border border-slate-800 bg-slate-950/95 shadow-[0_0_0_1px_rgba(15,23,42,0.25),0_24px_80px_rgba(2,6,23,0.6)]',
+          className || '',
+        ].filter(Boolean).join(' ')}
+      >
+        <ContentPane
+          path={normalizedPath}
+          content={content}
+          isLoading={isLoading}
+          error={error}
+          readOnly={resolvedReadOnly}
+          truncationInfo={resolvedTruncationInfo}
+          isEditing={isEditing}
+          editedContent={editedContent}
+          onEditStart={onEditStart}
+          onEditChange={onEditChange}
+          onSave={onSave}
+          onCancel={onCancel}
+          ariaLabel={ariaLabel || (normalizedPath ? `File content: ${normalizedPath}` : 'File content viewer')}
+        />
+      </div>
+    );
+  }
+
+  const breadcrumbSegments = (normalizedPath || 'Untitled')
+    .split('/')
+    .filter(Boolean);
 
   return (
     <div
       className={[
-        'overflow-hidden rounded-xl border border-slate-800 bg-slate-950/95 shadow-[0_0_0_1px_rgba(15,23,42,0.25),0_24px_80px_rgba(2,6,23,0.6)]',
+        'ccdash-content-viewer flex min-h-0 w-full flex-col overflow-hidden rounded-2xl border border-slate-800 bg-slate-950/95 shadow-[0_0_0_1px_rgba(15,23,42,0.25),0_24px_80px_rgba(2,6,23,0.6)]',
         className || '',
-      ]
-        .filter(Boolean)
-        .join(' ')}
+      ].filter(Boolean).join(' ')}
       data-content-viewer-mode={viewerMode}
+      role="region"
+      aria-label={ariaLabel || (normalizedPath ? `File content: ${normalizedPath}` : 'File content viewer')}
     >
-      <ContentPane
-        path={normalizedPath}
-        content={content}
-        isLoading={isLoading}
-        error={error}
-        readOnly={resolvedReadOnly}
-        truncationInfo={resolvedTruncationInfo}
-        isEditing={isEditing}
-        editedContent={editedContent}
-        onEditStart={onEditStart}
-        onEditChange={onEditChange}
-        onSave={onSave}
-        onCancel={onCancel}
-        ariaLabel={ariaLabel || (normalizedPath ? `File content: ${normalizedPath}` : 'File content viewer')}
-      />
+      <div className="flex items-center justify-between gap-4 border-b border-slate-800 bg-slate-950/80 px-4 py-3">
+        <div className="min-w-0">
+          <div className="mb-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+            {viewerMode === 'markdown' ? 'Markdown Preview' : 'File Preview'}
+          </div>
+          <nav className="flex min-w-0 flex-wrap items-center gap-1.5 text-xs text-slate-400" aria-label="File path">
+            {breadcrumbSegments.map((segment, index) => (
+              <React.Fragment key={`${segment}-${index}`}>
+                {index > 0 && <ChevronRight size={12} className="shrink-0 text-slate-600" />}
+                <span className={index === breadcrumbSegments.length - 1 ? 'font-medium text-slate-100' : ''}>
+                  {segment}
+                </span>
+              </React.Fragment>
+            ))}
+          </nav>
+        </div>
+        {canStartEdit && (
+          <button
+            type="button"
+            onClick={onEditStart}
+            className="inline-flex shrink-0 items-center gap-2 rounded-lg border border-slate-700 bg-slate-900/80 px-3 py-2 text-xs font-medium text-slate-200 transition-colors hover:border-indigo-500/40 hover:bg-indigo-500/10 hover:text-indigo-100"
+          >
+            <Edit3 size={14} />
+            Edit
+          </button>
+        )}
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-hidden p-4">
+        <div className="flex h-full min-h-0 flex-col gap-4">
+          {resolvedTruncationInfo?.truncated && (
+            <div className="flex items-start gap-3 rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-100">
+              <AlertTriangle size={16} className="mt-0.5 shrink-0 text-amber-300" />
+              <div>
+                <div className="font-medium text-amber-200">Large file truncated</div>
+                <div className="mt-1 text-xs text-amber-100/80">
+                  Showing a partial preview
+                  {typeof resolvedTruncationInfo.originalSize === 'number'
+                    ? ` of ${formatBytes(resolvedTruncationInfo.originalSize)}.`
+                    : '.'}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {parsedContent.frontmatter && (
+            <FrontmatterDisplay
+              frontmatter={parsedContent.frontmatter}
+              defaultCollapsed
+              className="shrink-0"
+            />
+          )}
+
+          {isLoading || error || !normalizedPath || content === null ? (
+            <div className="min-h-0 flex-1 overflow-hidden rounded-xl">
+              <ContentPane
+                path={normalizedPath}
+                content={content}
+                isLoading={isLoading}
+                error={error}
+                readOnly={resolvedReadOnly}
+                truncationInfo={resolvedTruncationInfo}
+                isEditing={false}
+                editedContent={editedContent}
+                onEditStart={onEditStart}
+                onEditChange={onEditChange}
+                onSave={onSave}
+                onCancel={onCancel}
+                ariaLabel={ariaLabel || (normalizedPath ? `File content: ${normalizedPath}` : 'File content viewer')}
+              />
+            </div>
+          ) : viewerMode === 'markdown' ? (
+            <div className="min-h-0 flex-1 overflow-auto rounded-xl border border-slate-800/80 bg-slate-950/70">
+              <div className="ccdash-markdown p-6 text-sm text-slate-200">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                  {parsedContent.displayContent || '*No content to preview*'}
+                </ReactMarkdown>
+              </div>
+            </div>
+          ) : (
+            <div className="min-h-0 flex-1 overflow-auto rounded-xl border border-slate-800/80 bg-slate-950/70">
+              <pre className="min-w-max p-4 font-mono text-xs leading-6 text-slate-200">
+                {parsedContent.displayContent || ''}
+              </pre>
+            </div>
+          )}
+        </div>
+      </div>
     </div>
   );
 };

--- a/components/content/UnifiedContentViewer.tsx
+++ b/components/content/UnifiedContentViewer.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { ContentPane, type TruncationInfo } from '@miethe/ui/content-viewer';
+import { getContentViewerMode } from '@/lib/contentViewer';
+import {
+  buildContentViewerTruncationInfo,
+  isContentViewerEditable,
+  normalizeContentViewerPath,
+} from '@/lib/contentViewer';
+
+export interface UnifiedContentViewerProps {
+  path: string | null;
+  content: string | null;
+  isLoading?: boolean;
+  error?: string | null;
+  readOnly?: boolean;
+  truncationInfo?: TruncationInfo | null;
+  isEditing?: boolean;
+  editedContent?: string;
+  onEditStart?: () => void;
+  onEditChange?: (content: string) => void;
+  onSave?: (content: string) => void | Promise<void>;
+  onCancel?: () => void;
+  ariaLabel?: string;
+  className?: string;
+}
+
+export const UnifiedContentViewer = ({
+  path,
+  content,
+  isLoading = false,
+  error = null,
+  readOnly = false,
+  truncationInfo,
+  isEditing = false,
+  editedContent = '',
+  onEditStart,
+  onEditChange,
+  onSave,
+  onCancel,
+  ariaLabel,
+  className,
+}: UnifiedContentViewerProps) => {
+  const normalizedPath = normalizeContentViewerPath(path);
+  const viewerMode = getContentViewerMode(normalizedPath);
+  const resolvedReadOnly = readOnly || !isContentViewerEditable(normalizedPath);
+  const resolvedTruncationInfo = buildContentViewerTruncationInfo(truncationInfo);
+
+  return (
+    <div
+      className={[
+        'overflow-hidden rounded-xl border border-slate-800 bg-slate-950/95 shadow-[0_0_0_1px_rgba(15,23,42,0.25),0_24px_80px_rgba(2,6,23,0.6)]',
+        className || '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      data-content-viewer-mode={viewerMode}
+    >
+      <ContentPane
+        path={normalizedPath}
+        content={content}
+        isLoading={isLoading}
+        error={error}
+        readOnly={resolvedReadOnly}
+        truncationInfo={resolvedTruncationInfo}
+        isEditing={isEditing}
+        editedContent={editedContent}
+        onEditStart={onEditStart}
+        onEditChange={onEditChange}
+        onSave={onSave}
+        onCancel={onCancel}
+        ariaLabel={ariaLabel || (normalizedPath ? `File content: ${normalizedPath}` : 'File content viewer')}
+      />
+    </div>
+  );
+};

--- a/components/content/__tests__/UnifiedContentViewer.test.tsx
+++ b/components/content/__tests__/UnifiedContentViewer.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { UnifiedContentViewer } from '../UnifiedContentViewer';
+
+describe('UnifiedContentViewer', () => {
+  it('renders normalized file paths and file content in read-only mode', () => {
+    const html = renderToStaticMarkup(
+      <UnifiedContentViewer
+        path="./docs/example.toml"
+        content={'title = "Demo"\n'}
+        readOnly
+      />,
+    );
+
+    expect(html).toContain('data-content-viewer-mode="code"');
+    expect(html).toContain('docs/example.toml');
+    expect(html).toContain('title = &quot;Demo&quot;');
+  });
+});

--- a/components/content/__tests__/UnifiedContentViewer.test.tsx
+++ b/components/content/__tests__/UnifiedContentViewer.test.tsx
@@ -18,4 +18,18 @@ describe('UnifiedContentViewer', () => {
     expect(html).toContain('docs/example.toml');
     expect(html).toContain('title = &quot;Demo&quot;');
   });
+
+  it('renders markdown-like content as formatted markdown in read-only mode', () => {
+    const html = renderToStaticMarkup(
+      <UnifiedContentViewer
+        path="./logs/output.txt"
+        content={'# Heading\n\n- first\n- second'}
+        readOnly
+      />,
+    );
+
+    expect(html).toContain('data-content-viewer-mode="markdown"');
+    expect(html).toContain('<h1>Heading</h1>');
+    expect(html).toContain('<li>first</li>');
+  });
 });

--- a/components/content/__tests__/UnifiedContentViewer.test.tsx
+++ b/components/content/__tests__/UnifiedContentViewer.test.tsx
@@ -32,4 +32,19 @@ describe('UnifiedContentViewer', () => {
     expect(html).toContain('<h1>Heading</h1>');
     expect(html).toContain('<li>first</li>');
   });
+
+  it('renders explicit frontmatter metadata when content is already stripped to the document body', () => {
+    const html = renderToStaticMarkup(
+      <UnifiedContentViewer
+        path="./docs/example.md"
+        content={'# Heading\n\nBody copy'}
+        frontmatter={{ title: 'Example Doc', status: 'draft' }}
+        readOnly
+      />,
+    );
+
+    expect(html).toContain('Frontmatter');
+    expect(html).toContain('Show frontmatter');
+    expect(html).toContain('<h1>Heading</h1>');
+  });
 });

--- a/docs/project_plans/PRDs/refactors/ccdash-theme-system-modernization-v1.md
+++ b/docs/project_plans/PRDs/refactors/ccdash-theme-system-modernization-v1.md
@@ -1,0 +1,179 @@
+---
+schema_name: ccdash_document
+schema_version: 3
+doc_type: prd
+doc_subtype: research_prd
+status: pending
+category: refactors
+title: "PRD: CCDash Theme System Modernization V1"
+description: "Refactor CCDash from a dark-only, palette-literal UI into a semantic token-driven application that supports standard theme modes and later custom user theming."
+summary: "Define the staged program required to establish a theme-system foundation, then deliver dark/light/system modes, then deliver user-defined themes."
+created: 2026-03-19
+updated: 2026-03-19
+priority: high
+risk_level: high
+complexity: High
+track: UI Platform
+timeline_estimate: "8-12 weeks across 3 sequential implementation plans"
+feature_slug: ccdash-theme-system-modernization-v1
+feature_family: ccdash-theme-system-modernization
+feature_version: v1
+lineage_family: ccdash-theme-system-modernization
+lineage_parent: ""
+lineage_children: []
+lineage_type: refactor
+problem_statement: "CCDash has the beginnings of a semantic theme system, but most of the actual product UI is still authored as a hard-coded dark theme, which blocks safe delivery of light mode and makes user-defined app-wide theming impractical."
+owner: fullstack-engineering
+owners: [fullstack-engineering, frontend-platform]
+contributors: [ai-agents]
+audience: [ai-agents, developers, fullstack-engineering, frontend-platform]
+tags: [prd, ui, theming, tailwind, refactor, dark-mode, light-mode, design-system]
+related_documents:
+  - docs/project_plans/reports/ccdash-theme-system-feasibility-and-migration-report-2026-03-19.md
+  - docs/project_plans/implementation_plans/refactors/ccdash-theme-system-foundation-v1.md
+  - docs/project_plans/implementation_plans/enhancements/ccdash-standard-theme-modes-v1.md
+  - docs/project_plans/implementation_plans/enhancements/ccdash-custom-theming-v1.md
+context_files:
+  - index.tsx
+  - src/index.css
+  - tailwind.config.js
+  - components/Layout.tsx
+  - components/Dashboard.tsx
+  - components/Analytics/AnalyticsDashboard.tsx
+  - components/Analytics/TrendChart.tsx
+  - components/content/UnifiedContentViewer.tsx
+  - components/Settings.tsx
+  - contexts/ModelColorsContext.tsx
+implementation_plan_ref: docs/project_plans/implementation_plans/refactors/ccdash-theme-system-foundation-v1.md
+---
+
+# PRD: CCDash Theme System Modernization V1
+
+## Executive Summary
+
+CCDash needs to evolve from a dark-themed application with partial token support into a true themeable web app. The current frontend already has a semantic token seed in Tailwind and CSS variables, but most of the real UI ignores that layer in favor of copied palette literals, dark-only global CSS, and hard-coded chart colors.
+
+This PRD defines a three-step modernization program:
+
+1. refactor the app so the UI styling contract is semantic and token-driven
+2. implement standard theme modes (`dark`, `light`, `system`)
+3. implement custom user theming on top of that stable contract
+
+The work must happen in this order. Theme modes and custom themes are product features, but they depend on the foundational refactor that converts the app away from palette-bound styling.
+
+## Context And Background
+
+CCDash already contains encouraging infrastructure:
+
+1. Tailwind semantic color mappings in `tailwind.config.js`
+2. light and dark token sets in `src/index.css`
+3. shadcn-style component metadata in `components.json`
+4. a small set of semantic UI primitives in `components/ui/`
+
+At the same time, the real product surface remains mostly dark-only:
+
+1. `index.tsx` forces `.dark` at startup
+2. `src/index.css` pins `color-scheme: dark`
+3. shell and feature pages are dominated by direct `slate`, `indigo`, `emerald`, `amber`, and `rose` classes
+4. charts and markdown surfaces use raw hex/RGB values
+5. large feature files duplicate surface, chip, and alert patterns instead of consuming shared variants
+
+## Problem Statement
+
+As CCDash continues to grow, I need the web app to support a stable, app-wide theme system instead of a dark-only styling convention. Today, the design token infrastructure exists, but the UI itself is not actually built on it. That gap makes light mode expensive, custom theming unreliable, and mass style updates overly risky.
+
+## Goals
+
+1. Establish a semantic theme contract for the entire app UI.
+2. Remove hard dependencies on dark-only palette literals from core product surfaces.
+3. Make standard theme modes (`dark`, `light`, `system`) a first-class app capability.
+4. Enable future user-defined themes through validated token maps and presets.
+5. Improve maintainability of mass style updates through shared primitives, variants, and chart theming infrastructure.
+
+## Success Metrics
+
+| Metric | Baseline | Target |
+|--------|----------|--------|
+| Hard-coded palette utility usage on app surfaces | Dominant | Majority of shared surfaces migrated to semantic tokens |
+| Dark-only bootstrap behavior | Forced `.dark` and dark `color-scheme` | Theme resolved from provider, persistence, and system preference |
+| Shared primitive adoption | Low | Core shell, alerts, surfaces, badges, and common controls standardized |
+| Chart theming consistency | File-by-file literals | Central chart theme adapter backed by tokens |
+| App-wide theme mode support | Dark only | Dark, Light, System |
+| User-defined theme capability | None | Supported through validated token presets after theme-mode rollout |
+
+## Functional Requirements
+
+| ID | Requirement | Priority | Notes |
+|----|-------------|----------|-------|
+| FR-1 | Introduce a semantic UI token contract that covers shell, surfaces, text, borders, states, overlays, and charts. | Must | Must extend beyond the current shadcn defaults. |
+| FR-2 | Refactor shared and repeated UI patterns to consume semantic primitives and variants instead of copied palette formulas. | Must | Includes panels, alerts, badges, status chips, and common controls. |
+| FR-3 | Remove hard-forced dark-mode bootstrap behavior and support resolved theme state at app root. | Must | Required before standard theme modes can ship. |
+| FR-4 | Deliver standard theme modes: `dark`, `light`, and `system`. | Must | Requires persistence and first-paint correctness. |
+| FR-5 | Theme markdown/content-viewer surfaces, global scrollbars, and overlays from semantic tokens. | Must | These are current dark-only bypasses. |
+| FR-6 | Centralize chart styling through token-backed configuration and defaults. | Must | Applies to Recharts surfaces and related chart legends/tooltips. |
+| FR-7 | Preserve data-driven accent systems such as model colors while separating them from base app theming. | Should | Prevents conflict between theme tokens and domain colors. |
+| FR-8 | Add user-defined theme presets built on validated token maps, not arbitrary CSS injection. | Must | This is the custom theming stage. |
+| FR-9 | Wire the existing Settings Theme control into real theme state and persistence. | Must | Existing control is currently placeholder UI only. |
+
+## Non-Functional Requirements
+
+1. Preserve current dark visual intent during the foundation refactor unless a plan explicitly changes product appearance.
+2. Avoid a big-bang rewrite; migrate in waves with shared surfaces first.
+3. Keep theme rendering stable on first paint and during app boot.
+4. Maintain accessible contrast ratios for text, borders, focus states, and data visualizations in both dark and light themes.
+5. Add guardrails or tests that reduce regressions back to palette-literal styling on shared surfaces.
+
+## In Scope
+
+1. Theme-system refactor of frontend styling architecture.
+2. Standard app theme modes and persistence.
+3. Custom user theming based on semantic token presets.
+4. Shared primitives and chart theming infrastructure required to support those outcomes.
+
+## Out Of Scope
+
+1. Arbitrary CSS injection or unrestricted user-authored stylesheets.
+2. A full visual redesign unrelated to theming architecture.
+3. Replacing all data-driven color usage with theme tokens.
+
+## Target State
+
+At the end of this program:
+
+1. The shell and shared UI surfaces render from semantic tokens rather than palette literals.
+2. Theme state is resolved centrally and applied before first paint.
+3. Dark and light mode are both valid, tested, and visually coherent.
+4. Charts, markdown, overlays, and global surfaces follow the same theme contract.
+5. Users can choose from standard modes and then optionally apply custom token presets that affect the entire app consistently.
+
+## Sequencing And Dependencies
+
+This program must be delivered as three sequential implementation plans:
+
+1. `docs/project_plans/implementation_plans/refactors/ccdash-theme-system-foundation-v1.md`
+   - prerequisite for all later work
+   - converts the app to semantic styling contracts and shared theming infrastructure
+2. `docs/project_plans/implementation_plans/enhancements/ccdash-standard-theme-modes-v1.md`
+   - depends on the foundation plan
+   - delivers `dark`, `light`, and `system`
+3. `docs/project_plans/implementation_plans/enhancements/ccdash-custom-theming-v1.md`
+   - depends on the standard theme modes plan
+   - delivers validated user-defined theme presets and customization
+
+## Risks And Mitigations
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| Styling migration churn in monolithic components slows delivery | High | High | Migrate by shared surface class first, then feature waves, and decompose large components where needed. |
+| Theme refactor accidentally changes dark-mode visuals too early | Medium | Medium | Keep the foundation plan scoped to semantic parity before introducing new modes. |
+| Light mode exposes many hidden contrast and readability issues | High | High | Treat chart, markdown, and status states as explicit validation tracks in the second plan. |
+| Custom theming becomes an unbounded CSS feature | High | Medium | Restrict customization to validated semantic token maps and presets. |
+| Data-driven accent colors conflict with app theme tokens | Medium | Medium | Keep domain-specific color systems explicitly separated from base app theme state. |
+
+## Acceptance Criteria
+
+1. The project has a documented three-stage roadmap for theme-system modernization.
+2. The foundation refactor has a clear contract for semantic UI tokens, shared primitives, and chart theming.
+3. Standard theme modes are planned as a dedicated delivery after semantic migration, not mixed into the foundation work.
+4. Custom theming is planned as a follow-on capability built on token presets and validated boundaries.
+5. The resulting planning artifacts are sufficient to execute the work in succession without reopening sequencing decisions.

--- a/docs/project_plans/implementation_plans/enhancements/ccdash-custom-theming-v1.md
+++ b/docs/project_plans/implementation_plans/enhancements/ccdash-custom-theming-v1.md
@@ -1,0 +1,193 @@
+---
+schema_name: ccdash_document
+schema_version: 3
+doc_type: implementation_plan
+doc_subtype: implementation_plan
+primary_doc_role: supporting_document
+status: pending
+category: enhancements
+title: "Implementation Plan: CCDash Custom Theming V1"
+description: "Enable user-defined themes in CCDash through validated token presets layered on top of the standard theme system."
+summary: "Add theme preset storage, validation, editing, preview, and application for app-wide semantic tokens while keeping data-driven domain colors explicitly separated."
+author: codex
+audience: [ai-agents, developers, fullstack-engineering, frontend-platform]
+created: 2026-03-19
+updated: 2026-03-19
+tags: [implementation, enhancement, theming, presets, customization, ui]
+priority: medium
+risk_level: medium
+complexity: medium
+track: UI Platform
+timeline_estimate: "2-4 weeks across 5 phases"
+feature_slug: ccdash-custom-theming-v1
+feature_family: ccdash-theme-system-modernization
+feature_version: v1
+lineage_family: ccdash-theme-system-modernization
+lineage_parent:
+  ref: docs/project_plans/implementation_plans/enhancements/ccdash-standard-theme-modes-v1.md
+  kind: prerequisite
+lineage_children: []
+lineage_type: enhancement
+linked_features: []
+related_documents:
+  - docs/project_plans/PRDs/refactors/ccdash-theme-system-modernization-v1.md
+  - docs/project_plans/implementation_plans/refactors/ccdash-theme-system-foundation-v1.md
+  - docs/project_plans/implementation_plans/enhancements/ccdash-standard-theme-modes-v1.md
+  - docs/project_plans/reports/ccdash-theme-system-feasibility-and-migration-report-2026-03-19.md
+context_files:
+  - components/Settings.tsx
+  - src/index.css
+  - tailwind.config.js
+  - contexts/ModelColorsContext.tsx
+  - lib/modelColors.ts
+  - components/ui/badge.tsx
+---
+
+# Implementation Plan: CCDash Custom Theming V1
+
+## Objective
+
+Enable users to apply their own app-wide UI themes to CCDash using validated semantic token presets layered on top of the standard theme system. This plan begins only after the foundation refactor and standard theme modes are complete.
+
+## Scope And Fixed Decisions
+
+In scope:
+
+1. Add a persistent user theme preset model.
+2. Allow users to customize semantic app tokens through approved controls.
+3. Support preview, apply, save, edit, duplicate, reset, and delete flows for presets.
+4. Keep compatibility with standard theme modes.
+5. Clearly separate app theme tokens from data-driven accent systems such as model colors.
+
+Out of scope:
+
+1. Arbitrary CSS text input.
+2. Unvalidated token names or raw stylesheet injection.
+3. Replacing model color overrides or other domain-specific color systems.
+
+Fixed decisions:
+
+1. Custom theming is token-map based.
+2. Only semantic theme tokens are user-customizable.
+3. Standard theme modes remain the outer runtime modes; custom themes specialize those semantics.
+
+## Preset Model Direction
+
+Each custom theme preset should define a validated set of semantic values for roles such as:
+
+1. app background and foreground
+2. panel surfaces and borders
+3. primary, secondary, accent, muted roles
+4. success, warning, danger, info roles
+5. chart roles and tooltip/grid roles
+6. radii or density-related style tokens only if the foundation and standard modes plans deem them stable enough
+
+The implementation may support separate dark and light token maps per preset or a single preset with mode-specific variants. The model must remain bounded and explicit.
+
+## Phase Overview
+
+| Phase | Title | Effort | Duration | Critical Path | Objective |
+|------|-------|--------|----------|---------------|-----------|
+| 1 | Preset Model And Validation | 7 pts | 3 days | Yes | Define storage schema, validation, and token boundaries |
+| 2 | Theme Preset Runtime Integration | 8 pts | 3-4 days | Yes | Apply presets on top of standard theme modes safely |
+| 3 | Settings UI And Editing Workflow | 10 pts | 4-5 days | Yes | Build user-facing preset management and editing |
+| 4 | Preview, Safety, And Recovery | 7 pts | 3 days | Yes | Add non-destructive preview, reset, and invalid-theme recovery |
+| 5 | QA, Accessibility, And Preset Governance | 7 pts | 3 days | Final gate | Validate custom themes and establish extension guardrails |
+
+**Total**: ~39 story points over 2-4 weeks
+
+## Implementation Strategy
+
+1. Start with preset schema and validation boundaries before building UI.
+2. Keep runtime application deterministic: base mode resolves first, custom preset overlays second.
+3. Build preview and recovery features before broadening editing flexibility.
+4. Treat accessibility and invalid-theme handling as core requirements, not polish.
+
+## Phase 1: Preset Model And Validation
+
+**Assigned Subagent(s)**: frontend-platform, ui-engineer-enhanced
+
+| Task ID | Task Name | Description | Acceptance Criteria | Estimate | Subagent(s) | Dependencies |
+|---------|-----------|-------------|---------------------|----------|-------------|--------------|
+| CUSTOM-001 | Preset Schema | Define the preset data model, stable token set, and per-mode behavior. | Preset schema is explicit, versionable, and scoped to supported semantic roles only. | 3 pts | frontend-platform | Standard theme modes plan complete |
+| CUSTOM-002 | Validation Rules | Add validation for color formats, missing required roles, and unsafe or unsupported values. | Invalid preset data cannot be applied silently. | 2 pts | frontend-platform | CUSTOM-001 |
+| CUSTOM-003 | Persistence Strategy | Define storage location and migration/versioning strategy for saved presets. | Presets persist safely and can evolve without breaking old entries. | 2 pts | frontend-platform | CUSTOM-001 |
+
+**Phase 1 Quality Gates**
+
+1. Preset schema is bounded and documented.
+2. Unsupported customization paths are rejected clearly.
+3. Storage and versioning are stable enough for user-facing management.
+
+## Phase 2: Theme Preset Runtime Integration
+
+**Assigned Subagent(s)**: frontend-developer, frontend-platform
+
+| Task ID | Task Name | Description | Acceptance Criteria | Estimate | Subagent(s) | Dependencies |
+|---------|-----------|-------------|---------------------|----------|-------------|--------------|
+| CUSTOM-101 | Runtime Overlay Model | Apply custom preset tokens on top of resolved dark/light/system mode without bypassing the provider. | Effective theme result is deterministic and mode-aware. | 3 pts | frontend-platform, frontend-developer | CUSTOM-003 |
+| CUSTOM-102 | Token Application Pipeline | Add a safe runtime path for applying preset values to CSS variables. | Presets affect the full app surface through the semantic token layer. | 3 pts | frontend-developer | CUSTOM-101 |
+| CUSTOM-103 | Exception-System Compatibility | Ensure model colors and other data-driven accents remain isolated from app theme preset changes. | Domain-specific color systems continue to work without being overridden unexpectedly. | 2 pts | frontend-platform | CUSTOM-102 |
+
+**Phase 2 Quality Gates**
+
+1. Presets apply app-wide through semantic tokens.
+2. Runtime application is mode-aware and reversible.
+3. Data-driven accents remain intentionally separate.
+
+## Phase 3: Settings UI And Editing Workflow
+
+**Assigned Subagent(s)**: ui-engineer-enhanced, frontend-developer
+
+| Task ID | Task Name | Description | Acceptance Criteria | Estimate | Subagent(s) | Dependencies |
+|---------|-----------|-------------|---------------------|----------|-------------|--------------|
+| CUSTOM-201 | Preset Management UI | Add Settings UI for listing, selecting, creating, duplicating, renaming, and deleting presets. | Users can manage presets without touching raw config. | 4 pts | ui-engineer-enhanced | CUSTOM-102 |
+| CUSTOM-202 | Token Editing UI | Add bounded editing controls for supported semantic token values. | Users can modify supported theme roles with validation feedback. | 4 pts | ui-engineer-enhanced, frontend-developer | CUSTOM-201 |
+| CUSTOM-203 | Default And Reset Flows | Support reset-to-standard-mode or reset-to-default-preset behavior. | Users can recover from unwanted visual changes quickly. | 2 pts | frontend-developer | CUSTOM-201 |
+
+**Phase 3 Quality Gates**
+
+1. Preset management is user-friendly and bounded.
+2. Editing stays inside validated token controls.
+3. Reset behavior is always available.
+
+## Phase 4: Preview, Safety, And Recovery
+
+**Assigned Subagent(s)**: frontend-developer, qa-engineer
+
+| Task ID | Task Name | Description | Acceptance Criteria | Estimate | Subagent(s) | Dependencies |
+|---------|-----------|-------------|---------------------|----------|-------------|--------------|
+| CUSTOM-301 | Non-Destructive Preview | Let users preview theme changes before committing them. | Users can inspect a preset without permanently applying it immediately. | 3 pts | frontend-developer | CUSTOM-202 |
+| CUSTOM-302 | Invalid Theme Recovery | Add fallback behavior for malformed, missing, or partially invalid preset data. | The app never becomes unreadable or stuck because of a bad preset. | 2 pts | frontend-developer | CUSTOM-301 |
+| CUSTOM-303 | Cross-Surface Preview Validation | Confirm preview behavior works across shell, charts, markdown, and table surfaces. | Preview is representative across major UI surfaces. | 2 pts | qa-engineer | CUSTOM-301 |
+
+**Phase 4 Quality Gates**
+
+1. Theme preview is safe and reversible.
+2. Fallback behavior is reliable.
+3. Preview reflects real app-wide coverage.
+
+## Phase 5: QA, Accessibility, And Preset Governance
+
+**Assigned Subagent(s)**: accessibility-engineer, qa-engineer, documentation-writer
+
+| Task ID | Task Name | Description | Acceptance Criteria | Estimate | Subagent(s) | Dependencies |
+|---------|-----------|-------------|---------------------|----------|-------------|--------------|
+| CUSTOM-401 | Custom Theme Accessibility Guardrails | Add validation or warnings for low-contrast or unsafe token combinations where feasible. | Users receive meaningful guardrails before saving clearly problematic presets. | 3 pts | accessibility-engineer | CUSTOM-303 |
+| CUSTOM-402 | Preset Regression Coverage | Add tests/checklists for preset apply/remove/preview behavior and persisted selection. | Custom-theme regressions are detectable. | 2 pts | qa-engineer | CUSTOM-401 |
+| CUSTOM-403 | Governance And Extensibility Docs | Document supported customizable roles, future expansion rules, and boundaries around data-driven colors. | Future preset expansion follows a stable contract. | 2 pts | documentation-writer | CUSTOM-402 |
+
+**Phase 5 Quality Gates**
+
+1. Presets are safe enough for general usage.
+2. Accessibility risks are surfaced or mitigated.
+3. Custom theming has clear long-term guardrails.
+
+## Exit Criteria
+
+This plan is complete when:
+
+1. Users can apply saved theme presets to the entire app through semantic tokens.
+2. Presets coexist correctly with dark/light/system base modes.
+3. Preview, reset, and invalid-theme recovery are reliable.
+4. Domain-specific accent systems remain separated from the base theme model.

--- a/docs/project_plans/implementation_plans/enhancements/ccdash-standard-theme-modes-v1.md
+++ b/docs/project_plans/implementation_plans/enhancements/ccdash-standard-theme-modes-v1.md
@@ -1,0 +1,189 @@
+---
+schema_name: ccdash_document
+schema_version: 3
+doc_type: implementation_plan
+doc_subtype: implementation_plan
+primary_doc_role: supporting_document
+status: pending
+category: enhancements
+title: "Implementation Plan: CCDash Standard Theme Modes V1"
+description: "Deliver standard app theme modes for CCDash after the theme-system foundation refactor: dark, light, and system."
+summary: "Introduce runtime theme resolution, persistence, first-paint correctness, light-mode token sets, and validation across shell, charts, content, and accessibility-sensitive surfaces."
+author: codex
+audience: [ai-agents, developers, fullstack-engineering, frontend-platform]
+created: 2026-03-19
+updated: 2026-03-19
+tags: [implementation, enhancement, theming, dark-mode, light-mode, system-theme]
+priority: high
+risk_level: medium
+complexity: medium
+track: UI Platform
+timeline_estimate: "2-3 weeks across 5 phases"
+feature_slug: ccdash-standard-theme-modes-v1
+feature_family: ccdash-theme-system-modernization
+feature_version: v1
+lineage_family: ccdash-theme-system-modernization
+lineage_parent:
+  ref: docs/project_plans/implementation_plans/refactors/ccdash-theme-system-foundation-v1.md
+  kind: prerequisite
+lineage_children:
+  - docs/project_plans/implementation_plans/enhancements/ccdash-custom-theming-v1.md
+lineage_type: enhancement
+linked_features: []
+related_documents:
+  - docs/project_plans/PRDs/refactors/ccdash-theme-system-modernization-v1.md
+  - docs/project_plans/implementation_plans/refactors/ccdash-theme-system-foundation-v1.md
+  - docs/project_plans/implementation_plans/enhancements/ccdash-custom-theming-v1.md
+context_files:
+  - index.tsx
+  - App.tsx
+  - src/index.css
+  - components/Settings.tsx
+  - components/Layout.tsx
+  - components/Dashboard.tsx
+  - components/Analytics/TrendChart.tsx
+  - components/content/UnifiedContentViewer.tsx
+  - contexts/ModelColorsContext.tsx
+---
+
+# Implementation Plan: CCDash Standard Theme Modes V1
+
+## Objective
+
+Ship the first user-facing theme modes for CCDash:
+
+1. `dark`
+2. `light`
+3. `system`
+
+This plan assumes the foundation refactor is complete and the app now renders through semantic tokens rather than palette-literal shared surfaces.
+
+## Scope And Fixed Decisions
+
+In scope:
+
+1. Add root theme state management and first-paint resolution.
+2. Support persisted theme preference and system preference fallback.
+3. Implement light-mode tokens and validate dark-mode parity.
+4. Wire the existing Settings Theme selector into real behavior.
+5. Validate charts, markdown, tables, content viewer, badges, and selected states under both modes.
+
+Out of scope:
+
+1. User-defined theme editing.
+2. Preset import/export.
+3. Arbitrary token override UI.
+
+Fixed decisions:
+
+1. Theme state resolves at app root before visible paint when possible.
+2. `system` follows `prefers-color-scheme`.
+3. Standard mode delivery does not change data-driven color override systems.
+
+## Phase Overview
+
+| Phase | Title | Effort | Duration | Critical Path | Objective |
+|------|-------|--------|----------|---------------|-----------|
+| 1 | Theme Runtime And Persistence | 7 pts | 3 days | Yes | Add provider, storage, and boot-time resolution |
+| 2 | Standard Mode Token Sets | 8 pts | 3-4 days | Yes | Finalize dark/light token definitions and `color-scheme` handling |
+| 3 | Settings And App Wiring | 6 pts | 2-3 days | Yes | Connect UI controls and route the resolved theme through the app |
+| 4 | Surface And Chart Verification | 8 pts | 3-4 days | Yes | Validate shell, viewer, and chart behavior under all modes |
+| 5 | Accessibility, QA, And Rollout | 6 pts | 2-3 days | Final gate | Confirm contrast, regression coverage, and readiness for custom theming |
+
+**Total**: ~35 story points over 2-3 weeks
+
+## Implementation Strategy
+
+1. Add the provider and persistence first so the rest of the app has a stable runtime contract.
+2. Finalize token sets before wiring Settings or testing charts.
+3. Validate first-paint correctness early to avoid flash-of-wrong-theme regressions.
+4. Treat charts and content-heavy surfaces as dedicated verification tracks, not incidental QA.
+
+## Phase 1: Theme Runtime And Persistence
+
+**Assigned Subagent(s)**: frontend-platform, frontend-developer
+
+| Task ID | Task Name | Description | Acceptance Criteria | Estimate | Subagent(s) | Dependencies |
+|---------|-----------|-------------|---------------------|----------|-------------|--------------|
+| MODE-001 | Theme State Model | Define the theme preference model for `dark`, `light`, and `system` plus resolved runtime theme. | Theme contract is explicit and usable from app root and Settings UI. | 2 pts | frontend-platform | Foundation plan complete |
+| MODE-002 | Theme Provider | Add a root provider that resolves, stores, and exposes current preference and effective theme. | App can read/write theme preference centrally. | 3 pts | frontend-developer | MODE-001 |
+| MODE-003 | Boot-Time Resolution | Replace hard-forced `.dark` bootstrap with resolved theme application and no incorrect default mode flash. | `index.tsx` no longer forces dark; boot path respects saved or system mode. | 2 pts | frontend-platform | MODE-002 |
+
+**Phase 1 Quality Gates**
+
+1. Theme state is centralized.
+2. Theme preference persists reliably.
+3. First paint resolves the correct mode.
+
+## Phase 2: Standard Mode Token Sets
+
+**Assigned Subagent(s)**: ui-engineer-enhanced, frontend-platform
+
+| Task ID | Task Name | Description | Acceptance Criteria | Estimate | Subagent(s) | Dependencies |
+|---------|-----------|-------------|---------------------|----------|-------------|--------------|
+| MODE-101 | Dark Token Finalization | Validate and adjust dark token values after the foundation refactor to preserve intended visual baseline. | Dark mode remains coherent under resolved theme runtime. | 3 pts | ui-engineer-enhanced | MODE-003 |
+| MODE-102 | Light Token Definition | Define light token values for shell, surfaces, states, charts, and content surfaces. | Light mode token set is complete for all semantic roles established in the foundation plan. | 3 pts | ui-engineer-enhanced, frontend-platform | MODE-003 |
+| MODE-103 | Color-Scheme And Browser Surface Handling | Make `color-scheme`, scrollbars, and other browser-controlled surfaces follow resolved theme correctly. | Browser-native chrome aligns with light/dark mode. | 2 pts | frontend-platform | MODE-102 |
+
+**Phase 2 Quality Gates**
+
+1. Semantic tokens produce valid dark and light results.
+2. Browser-level surfaces follow theme correctly.
+3. No shared surface depends on hidden dark-only assumptions.
+
+## Phase 3: Settings And App Wiring
+
+**Assigned Subagent(s)**: frontend-developer
+
+| Task ID | Task Name | Description | Acceptance Criteria | Estimate | Subagent(s) | Dependencies |
+|---------|-----------|-------------|---------------------|----------|-------------|--------------|
+| MODE-201 | Settings Theme Selector Wiring | Connect the existing Theme selector in `Settings.tsx` to real provider state and persistence. | Selecting a theme updates the app and persists preference. | 3 pts | frontend-developer | MODE-103 |
+| MODE-202 | App-Level Consumption Cleanup | Ensure shell and relevant pages consume resolved theme state only through provider and tokens, not local theme logic. | Theme behavior is centralized and consistent. | 2 pts | frontend-developer | MODE-201 |
+| MODE-203 | Developer Debug Hooks | Add lightweight debug visibility for active preference/resolved mode during validation if needed. | Theme QA can verify mode state deterministically. | 1 pt | frontend-developer | MODE-202 |
+
+**Phase 3 Quality Gates**
+
+1. Settings UI reflects real app state.
+2. Theme switching is stable and immediate.
+3. No duplicate theme state exists in page components.
+
+## Phase 4: Surface And Chart Verification
+
+**Assigned Subagent(s)**: qa-engineer, data-viz-ui, frontend-developer
+
+| Task ID | Task Name | Description | Acceptance Criteria | Estimate | Subagent(s) | Dependencies |
+|---------|-----------|-------------|---------------------|----------|-------------|--------------|
+| MODE-301 | Core Surface Verification | Validate shell, navigation, settings, content viewer, tables, and overlays in dark/light/system. | All major shared surfaces render legibly and consistently in each mode. | 3 pts | qa-engineer | MODE-202 |
+| MODE-302 | Chart Verification | Validate chart axes, grid, gradients, tooltips, series defaults, and legends in both modes. | Charts remain readable and visually coherent in dark and light themes. | 3 pts | data-viz-ui, qa-engineer | MODE-202 |
+| MODE-303 | Edge-State Verification | Validate status chips, alerts, selection states, hover states, and focus states in both modes. | State semantics remain understandable without palette regressions. | 2 pts | frontend-developer, qa-engineer | MODE-301 |
+
+**Phase 4 Quality Gates**
+
+1. Charts are production-ready in both modes.
+2. Content-heavy surfaces such as markdown and tables remain readable.
+3. State colors and focus affordances survive the mode expansion.
+
+## Phase 5: Accessibility, QA, And Rollout
+
+**Assigned Subagent(s)**: accessibility-engineer, qa-engineer, documentation-writer
+
+| Task ID | Task Name | Description | Acceptance Criteria | Estimate | Subagent(s) | Dependencies |
+|---------|-----------|-------------|---------------------|----------|-------------|--------------|
+| MODE-401 | Contrast And Accessibility Pass | Validate text, border, and focus contrast in both modes for critical UI states. | Accessibility-sensitive surfaces meet agreed contrast expectations. | 2 pts | accessibility-engineer | MODE-303 |
+| MODE-402 | Regression Coverage | Add or update tests/checklists for theme persistence, resolved mode selection, and core surface parity. | Theme-mode regressions are detectable. | 2 pts | qa-engineer | MODE-401 |
+| MODE-403 | Custom Theming Handoff | Document remaining assumptions, stable token APIs, and extension points for user-defined theming. | Next plan can layer customization on top of standard modes without revisiting runtime fundamentals. | 2 pts | documentation-writer | MODE-402 |
+
+**Phase 5 Quality Gates**
+
+1. Standard modes are feature-complete.
+2. Accessibility-sensitive surfaces are validated.
+3. Custom theming is unblocked.
+
+## Exit Criteria
+
+This plan is complete when:
+
+1. CCDash supports `dark`, `light`, and `system`.
+2. Theme preference persists and resolves correctly at boot.
+3. Shared surfaces, charts, markdown, and app shell are validated in both modes.
+4. The platform is ready for user-defined theming on top of the standard theme contract.

--- a/docs/project_plans/implementation_plans/enhancements/shared-content-viewer-standardization-v1.md
+++ b/docs/project_plans/implementation_plans/enhancements/shared-content-viewer-standardization-v1.md
@@ -1,6 +1,6 @@
 ---
 doc_type: implementation_plan
-status: in-progress
+status: completed
 category: enhancements
 
 title: "Implementation Plan: Shared Content Viewer Standardization V1"

--- a/docs/project_plans/implementation_plans/enhancements/shared-content-viewer-standardization-v1.md
+++ b/docs/project_plans/implementation_plans/enhancements/shared-content-viewer-standardization-v1.md
@@ -1,6 +1,6 @@
 ---
 doc_type: implementation_plan
-status: draft
+status: in-progress
 category: enhancements
 
 title: "Implementation Plan: Shared Content Viewer Standardization V1"
@@ -8,7 +8,7 @@ description: "Adopt @miethe/ui content viewer components in CCDash to unify docu
 author: codex
 audience: [ai-agents, developers, engineering-leads]
 created: 2026-03-15
-updated: 2026-03-15
+updated: 2026-03-19
 
 tags: [implementation, frontend, ui, documents, content-viewer, markdown]
 feature_slug: shared-content-viewer-standardization-v1

--- a/docs/project_plans/implementation_plans/refactors/ccdash-theme-system-foundation-v1.md
+++ b/docs/project_plans/implementation_plans/refactors/ccdash-theme-system-foundation-v1.md
@@ -1,0 +1,241 @@
+---
+schema_name: ccdash_document
+schema_version: 3
+doc_type: implementation_plan
+doc_subtype: implementation_plan
+primary_doc_role: supporting_document
+status: pending
+category: refactors
+title: "Implementation Plan: CCDash Theme System Foundation V1"
+description: "Refactor CCDash UI styling from dark-only palette composition to a semantic token-driven architecture that can safely support standard theme modes and later user-defined themes."
+summary: "Establish the semantic styling contract, shared primitives, chart theming layer, and migration guardrails required before dark/light/system or custom theming work begins."
+author: codex
+audience: [ai-agents, developers, fullstack-engineering, frontend-platform]
+created: 2026-03-19
+updated: 2026-03-19
+tags: [implementation, refactor, theming, tailwind, ui, design-system]
+priority: high
+risk_level: high
+complexity: high
+track: UI Platform
+timeline_estimate: "4-6 weeks across 6 phases"
+feature_slug: ccdash-theme-system-foundation-v1
+feature_family: ccdash-theme-system-modernization
+feature_version: v1
+lineage_family: ccdash-theme-system-modernization
+lineage_parent:
+  ref: docs/project_plans/PRDs/refactors/ccdash-theme-system-modernization-v1.md
+  kind: implementation_of
+lineage_children:
+  - docs/project_plans/implementation_plans/enhancements/ccdash-standard-theme-modes-v1.md
+lineage_type: refactor
+linked_features: []
+related_documents:
+  - docs/project_plans/reports/ccdash-theme-system-feasibility-and-migration-report-2026-03-19.md
+  - docs/project_plans/PRDs/refactors/ccdash-theme-system-modernization-v1.md
+  - docs/project_plans/implementation_plans/enhancements/ccdash-standard-theme-modes-v1.md
+context_files:
+  - index.tsx
+  - src/index.css
+  - tailwind.config.js
+  - components/Layout.tsx
+  - components/Dashboard.tsx
+  - components/Analytics/AnalyticsDashboard.tsx
+  - components/Analytics/TrendChart.tsx
+  - components/content/UnifiedContentViewer.tsx
+  - components/Settings.tsx
+  - components/featureStatus.ts
+---
+
+# Implementation Plan: CCDash Theme System Foundation V1
+
+## Objective
+
+Convert CCDash from a palette-literal dark UI into a semantic token-driven frontend architecture while preserving the current dark appearance as the default visual baseline. This plan does not ship user-facing light mode yet. Its job is to make the app structurally ready for that next step.
+
+## Scope And Fixed Decisions
+
+In scope:
+
+1. Expand the app-wide semantic theme contract beyond the current shadcn defaults.
+2. Replace repeated shell, surface, badge, alert, and state formulas with shared primitives or variants.
+3. Remove dark-only global CSS escape hatches by moving them onto token-backed styling.
+4. Add a centralized chart theme layer.
+5. Migrate the highest-leverage product surfaces from palette literals to semantic tokens.
+6. Add tests, rules, or review guardrails to discourage regression on shared surfaces.
+
+Out of scope:
+
+1. Shipping user-facing `light` or `system` mode.
+2. Building a custom theme editor.
+3. Reworking all domain-specific inline color use cases.
+
+Non-negotiables:
+
+1. The default appearance should remain visually close to current dark mode during this plan.
+2. Shared surfaces must migrate before page-specific edge cases.
+3. Chart theming must be centralized, not fixed ad hoc.
+
+## Proposed Theme Contract Targets
+
+Introduce or formalize semantic roles for:
+
+1. `app-background`, `app-foreground`
+2. `panel`, `panel-foreground`, `panel-border`
+3. `sidebar`, `sidebar-foreground`, `sidebar-accent`
+4. `surface-muted`, `surface-elevated`, `surface-overlay`
+5. `success`, `warning`, `danger`, `info`, plus foreground/border companions
+6. `chart-grid`, `chart-axis`, `chart-tooltip`, `chart-tooltip-foreground`
+7. `selection`, `focus`, `hover`, and `disabled`
+
+The exact variable names can vary, but the contract must be broad enough that future theme changes do not require page-level palette surgery.
+
+## Phase Overview
+
+| Phase | Title | Effort | Duration | Critical Path | Objective |
+|------|-------|--------|----------|---------------|-----------|
+| 1 | Semantic Theme Contract | 8 pts | 3-4 days | Yes | Expand and document the token vocabulary |
+| 2 | Global CSS And Shared Primitive Refactor | 10 pts | 4-5 days | Yes | Tokenize globals and add reusable UI building blocks |
+| 3 | Status, Alert, And Chart Infrastructure | 10 pts | 4-5 days | Yes | Centralize color semantics and chart defaults |
+| 4 | Shell And Shared Surface Migration | 10 pts | 4-5 days | Yes | Migrate layout, settings shell, content viewer, and shared surfaces |
+| 5 | Feature Surface Migration Waves | 14 pts | 1.5 weeks | Yes | Migrate high-traffic feature pages away from palette literals |
+| 6 | Guardrails, Validation, And Handoff | 8 pts | 3-4 days | Final gate | Lock in the contract and prepare the theme-modes plan |
+
+**Total**: ~60 story points over 4-6 weeks
+
+## Implementation Strategy
+
+### Critical Path
+
+1. Define the semantic contract before creating new components.
+2. Tokenize globals and shared components before migrating feature pages.
+3. Centralize chart and status semantics before touching chart-heavy screens.
+4. Migrate shell and reusable surfaces before monolithic feature files.
+5. End with validation and guardrails so the next plan inherits a stable base.
+
+### Parallel Work Opportunities
+
+1. Phase 3 chart infrastructure can begin once Phase 1 finalizes naming and token semantics.
+2. Phase 4 shared surface migration and Phase 5 feature-page migration can overlap once primitives are stable.
+3. Documentation and lint/test guardrails can be added incrementally after each migration wave.
+
+### Migration Order
+
+1. Tokens and globals
+2. Shared primitives
+3. Layout and content viewer
+4. Status/alert/chart infrastructure
+5. High-leverage screens: Dashboard, Analytics, Settings, Test Visualizer shells
+6. Monolithic screens: FeatureExecutionWorkbench, ProjectBoard, SessionInspector
+
+## Phase 1: Semantic Theme Contract
+
+**Assigned Subagent(s)**: frontend-platform, ui-engineer-enhanced
+
+| Task ID | Task Name | Description | Acceptance Criteria | Estimate | Subagent(s) | Dependencies |
+|---------|-----------|-------------|---------------------|----------|-------------|--------------|
+| THEME-001 | Token Inventory | Audit current token usage, palette-literal hotspots, and global CSS bypasses. | Token inventory and migration map exist for shell, surfaces, status states, charts, and viewer surfaces. | 2 pts | frontend-platform | None |
+| THEME-002 | Semantic Role Design | Define the semantic token vocabulary needed beyond current shadcn defaults. | Contract covers shell, panels, state colors, charts, overlays, and content surfaces. | 3 pts | ui-engineer-enhanced, frontend-platform | THEME-001 |
+| THEME-003 | Tailwind Mapping Plan | Define how new semantic roles map into CSS variables and Tailwind utilities. | Tailwind extension approach is agreed and documented. | 3 pts | frontend-platform | THEME-002 |
+
+**Phase 1 Quality Gates**
+
+1. Semantic token contract is broad enough to express all current repeated surface patterns.
+2. Status and chart semantics are explicitly included, not deferred.
+3. Future theme-mode work can consume this contract without reopening naming.
+
+## Phase 2: Global CSS And Shared Primitive Refactor
+
+**Assigned Subagent(s)**: frontend-developer, ui-engineer-enhanced
+
+| Task ID | Task Name | Description | Acceptance Criteria | Estimate | Subagent(s) | Dependencies |
+|---------|-----------|-------------|---------------------|----------|-------------|--------------|
+| THEME-101 | Base CSS Tokenization | Move dark-only scrollbar, markdown, overlay, and content-viewer-adjacent global styles onto CSS variables. | `src/index.css` no longer contains dark-only raw values for shared global surfaces without token backing. | 4 pts | frontend-developer | THEME-003 |
+| THEME-102 | Shared Surface Primitives | Create reusable surface primitives or class variants for panels, section shells, alerts, and control rows. | Repeated `bg-slate-900 border border-slate-800` patterns are replaceable through shared semantics. | 3 pts | ui-engineer-enhanced, frontend-developer | THEME-003 |
+| THEME-103 | Shared Control Standardization | Standardize common button/input/select/chip patterns around semantic variants. | Shared control patterns exist for future migration waves. | 3 pts | ui-engineer-enhanced | THEME-102 |
+
+**Phase 2 Quality Gates**
+
+1. Shared surfaces and common controls have semantic building blocks.
+2. Global CSS no longer encodes dark-only assumptions for shared content surfaces.
+3. New primitives are documented well enough for broad adoption.
+
+## Phase 3: Status, Alert, And Chart Infrastructure
+
+**Assigned Subagent(s)**: frontend-platform, data-viz-ui, frontend-developer
+
+| Task ID | Task Name | Description | Acceptance Criteria | Estimate | Subagent(s) | Dependencies |
+|---------|-----------|-------------|---------------------|----------|-------------|--------------|
+| THEME-201 | Status Semantic Layer | Replace raw success/warning/error/info formulas with semantic status variants. | `featureStatus.ts` and shared badge-like systems no longer hard-code product semantics directly to palette literals. | 3 pts | frontend-platform | THEME-102 |
+| THEME-202 | Chart Theme Adapter | Build a centralized Recharts theme adapter for grid, axis, tooltip, series defaults, and gradients. | Shared chart config exists and can remove duplicated dark hex values from chart files. | 4 pts | data-viz-ui, frontend-developer | THEME-003 |
+| THEME-203 | Dynamic Color Escape-Hatch Rules | Document and codify which inline/data-driven colors remain allowed and how they coexist with base theming. | Model colors and domain-specific accents are clearly separated from app theme tokens. | 3 pts | frontend-platform | THEME-201 |
+
+**Phase 3 Quality Gates**
+
+1. Shared status semantics are token-based.
+2. Charts can inherit themed defaults without per-file literal rewrites.
+3. Exception paths for data-driven colors are bounded and documented.
+
+## Phase 4: Shell And Shared Surface Migration
+
+**Assigned Subagent(s)**: frontend-developer, ui-engineer-enhanced
+
+| Task ID | Task Name | Description | Acceptance Criteria | Estimate | Subagent(s) | Dependencies |
+|---------|-----------|-------------|---------------------|----------|-------------|--------------|
+| THEME-301 | App Shell Migration | Migrate `Layout.tsx` and other shell-level surfaces to semantic tokens and shared primitives. | Sidebar, main content surfaces, nav states, and notifications no longer rely on raw palette formulas. | 4 pts | frontend-developer | THEME-201 |
+| THEME-302 | Settings And Theme-Adjacent Surface Migration | Migrate `Settings.tsx` shared shells, cards, alerts, and control rows to semantic surfaces. | Theme settings and model color configuration surfaces consume shared semantic primitives. | 3 pts | ui-engineer-enhanced | THEME-103 |
+| THEME-303 | Content Viewer Migration | Migrate `UnifiedContentViewer` and markdown wrappers to semantic tokens and global roles. | Content preview surfaces can follow future theme changes without file-local dark rewrites. | 3 pts | frontend-developer | THEME-101 |
+
+**Phase 4 Quality Gates**
+
+1. The app shell is no longer dark-palette locked.
+2. The Settings page and content viewer act as examples of the new contract.
+3. Shared surfaces are ready for standard theme modes.
+
+## Phase 5: Feature Surface Migration Waves
+
+**Assigned Subagent(s)**: frontend-developer, ui-engineer-enhanced, codebase-janitor
+
+| Task ID | Task Name | Description | Acceptance Criteria | Estimate | Subagent(s) | Dependencies |
+|---------|-----------|-------------|---------------------|----------|-------------|--------------|
+| THEME-401 | Analytics And Dashboard Wave | Migrate `Dashboard.tsx`, analytics shells, and shared metric cards to semantic surfaces and chart adapter usage. | Dashboard and analytics surfaces no longer depend on dynamic palette strings or chart literals. | 4 pts | frontend-developer | THEME-202 |
+| THEME-402 | Testing And Workflow Wave | Migrate test-visualizer and workflow registry surfaces to semantic primitives and status variants. | Test and workflow pages consume shared semantic shells and status semantics. | 4 pts | ui-engineer-enhanced | THEME-201 |
+| THEME-403 | Monolithic Page Wave | Migrate the most styling-dense monolithic pages in staged slices: FeatureExecutionWorkbench, ProjectBoard, SessionInspector. | High-risk pages are materially migrated away from repeated palette formulas without visual regressions. | 6 pts | codebase-janitor, frontend-developer | THEME-401 |
+
+**Phase 5 Quality Gates**
+
+1. Core product surfaces now render through semantic contracts.
+2. Dynamic palette string construction is removed from shared UI paths.
+3. High-traffic screens are no longer the main blocker for theme-mode rollout.
+
+## Phase 6: Guardrails, Validation, And Handoff
+
+**Assigned Subagent(s)**: frontend-platform, qa-engineer, documentation-writer
+
+| Task ID | Task Name | Description | Acceptance Criteria | Estimate | Subagent(s) | Dependencies |
+|---------|-----------|-------------|---------------------|----------|-------------|--------------|
+| THEME-501 | Guardrails And Review Rules | Add lint guidance, code review rules, or lightweight tests to discourage new palette-literal usage on shared surfaces. | Shared surface regressions are detectable in review or CI. | 3 pts | frontend-platform | THEME-403 |
+| THEME-502 | Dark-Parity Validation | Validate that semantic migration preserved intended dark-mode appearance for major surfaces and charts. | Visual parity checklist is completed and deviations are intentional/documented. | 3 pts | qa-engineer | THEME-403 |
+| THEME-503 | Theme Modes Handoff | Document resolved token contract, open gaps, and readiness criteria for the standard theme modes plan. | Next plan can begin without re-auditing foundation decisions. | 2 pts | documentation-writer, frontend-platform | THEME-501 |
+
+**Phase 6 Quality Gates**
+
+1. The app is semantically theme-ready even if only dark mode is exposed.
+2. Shared surfaces and charts have guardrails against regression.
+3. Standard theme modes are unblocked.
+
+## Validation And Test Strategy
+
+1. Snapshot or visual-regression coverage for core shell and shared surfaces.
+2. Focused test coverage for chart theme adapter behavior.
+3. Manual parity review for markdown, content viewer, tables, alerts, and selected states.
+4. Review checklist updates for semantic token usage versus palette-literal exceptions.
+
+## Exit Criteria
+
+This plan is complete when:
+
+1. CCDash shared surfaces are primarily semantic-token driven.
+2. Chart theming and status semantics are centralized.
+3. Global CSS no longer hard-codes dark-only shared surfaces.
+4. The app is structurally ready for `dark`, `light`, and `system` theme delivery.

--- a/docs/project_plans/reports/ccdash-theme-system-feasibility-and-migration-report-2026-03-19.md
+++ b/docs/project_plans/reports/ccdash-theme-system-feasibility-and-migration-report-2026-03-19.md
@@ -1,0 +1,215 @@
+---
+schema_name: ccdash_document
+schema_version: 3
+doc_type: report
+doc_subtype: analysis
+status: pending
+category: product
+title: "CCDash Theme System Feasibility And Migration Report"
+description: "Feasibility assessment for introducing a real theme system, light mode, and user-defined theming across the CCDash web app."
+summary: "Confirms that CCDash has a usable token foundation but requires a broad UI refactor before dark/light/system modes and custom themes can be delivered safely."
+created: 2026-03-19
+updated: 2026-03-19
+priority: high
+risk_level: medium
+report_kind: feasibility
+scope: ccdash-theme-system-modernization
+owner: fullstack-engineering
+owners: [fullstack-engineering, frontend-platform]
+contributors: [ai-agents]
+audience: [developers, fullstack-engineering, frontend-platform]
+tags: [report, theming, tailwind, ui, refactor, dark-mode, light-mode]
+related_documents:
+  - docs/project_plans/PRDs/refactors/ccdash-theme-system-modernization-v1.md
+  - docs/project_plans/implementation_plans/refactors/ccdash-theme-system-foundation-v1.md
+  - docs/project_plans/implementation_plans/enhancements/ccdash-standard-theme-modes-v1.md
+  - docs/project_plans/implementation_plans/enhancements/ccdash-custom-theming-v1.md
+evidence:
+  - index.tsx
+  - src/index.css
+  - tailwind.config.js
+  - components/Layout.tsx
+  - components/Dashboard.tsx
+  - components/Analytics/AnalyticsDashboard.tsx
+  - components/Analytics/TrendChart.tsx
+  - components/content/UnifiedContentViewer.tsx
+  - components/Settings.tsx
+  - contexts/ModelColorsContext.tsx
+recommendations:
+  - Execute a theme-foundation refactor before shipping light mode or user-defined themes.
+  - Move the app from palette-based styling to semantic token-based styling with shared UI primitives.
+  - Treat chart theming, markdown theming, and status-color semantics as first-class token systems.
+  - Deliver dark/light/system after the refactor, then build custom theming on top of that stable semantic layer.
+impacted_features:
+  - ccdash-theme-system-modernization-v1
+  - ccdash-theme-system-foundation-v1
+  - ccdash-standard-theme-modes-v1
+  - ccdash-custom-theming-v1
+---
+
+# CCDash Theme System Feasibility And Migration Report
+
+## Executive Summary
+
+Creating a real theme system for CCDash is feasible. The app already contains the essential infrastructure needed for token-driven theming: Tailwind is configured for CSS-variable-backed semantic colors, dark mode is class-based, and the codebase includes a small but valid set of shadcn-style UI primitives.
+
+The limiting factor is not missing tooling. The limiting factor is that the product UI is still authored primarily as a dark-only application built from hard-coded `slate`, `indigo`, `emerald`, `amber`, `rose`, and raw hex/RGB values. The current architecture supports themeability in theory, but the actual UI surface does not consistently consume that architecture.
+
+## Current State Findings
+
+### 1. A Token Foundation Exists
+
+1. `tailwind.config.js` already maps semantic colors such as `background`, `foreground`, `card`, `primary`, `secondary`, `muted`, `accent`, `destructive`, `border`, `input`, `ring`, and `chart-*` to CSS variables.
+2. `src/index.css` already defines both `:root` and `.dark` token sets.
+3. `components.json` confirms a shadcn-style setup with `cssVariables: true`.
+4. `components/ui/button.tsx`, `components/ui/input.tsx`, `components/ui/popover.tsx`, and `components/ui/tooltip.tsx` correctly use semantic utilities rather than palette literals.
+
+### 2. Product Surfaces Mostly Bypass The Token Layer
+
+1. Regex audit found about `6341` hard-coded palette utility matches across the frontend versus about `37` semantic-token utility matches.
+2. Shared primitive import adoption is low; most feature pages still hand-roll buttons, panels, alerts, and chips.
+3. `components/Layout.tsx`, `components/Dashboard.tsx`, `components/Analytics/AnalyticsDashboard.tsx`, `components/Settings.tsx`, `components/FeatureExecutionWorkbench.tsx`, `components/ProjectBoard.tsx`, and `components/SessionInspector.tsx` are dominated by literal dark palette classes.
+
+### 3. Dark Mode Is Structural, Not Just Visual
+
+1. `index.tsx` hard-adds `.dark` to both `document.documentElement` and `document.body`.
+2. `src/index.css` sets `color-scheme: dark` globally.
+3. The current Theme selector in `components/Settings.tsx` is presentational only and is not wired to state, persistence, or boot behavior.
+
+### 4. Global Styling Has Dark-Only Escape Hatches
+
+1. Scrollbars in `src/index.css` use hard-coded dark hex values.
+2. Markdown/content viewer styles in `src/index.css` and `components/content/UnifiedContentViewer.tsx` use raw dark RGB values and shadows.
+3. Many page-level alerts, overlays, and panel shells use copied literal color formulas instead of semantic variants.
+
+### 5. Charts And Visualizations Need Their Own Theme Layer
+
+1. Recharts configurations in `components/Dashboard.tsx`, `components/Analytics/TrendChart.tsx`, `components/Analytics/AnalyticsDashboard.tsx`, `components/TestVisualizer/TestTimeline.tsx`, and parts of `components/SessionInspector.tsx` hard-code grid, axis, tooltip, and series colors.
+2. The presence of `--chart-*` tokens in `src/index.css` is promising, but those tokens are not being consumed consistently.
+3. A chart theme adapter is required; file-by-file fixes would be noisy and fragile.
+
+### 6. Some Dynamic And Inline Color Paths Must Remain Explicit Exceptions
+
+1. `contexts/ModelColorsContext.tsx` and `lib/modelColors.ts` already support user-defined model badge colors via `localStorage`.
+2. `components/ui/badge.tsx`, `components/TranscriptMappedMessageCard.tsx`, and parts of `components/SessionMappings.tsx` intentionally use computed inline colors.
+3. These paths are not inherently wrong, but they must be separated conceptually from base app theming so the future system distinguishes:
+   - app semantic theme tokens
+   - data-driven accent colors
+   - user-specific visualization colors
+
+## Architectural Assessment
+
+### Strengths
+
+1. Central app shell via `App.tsx` and `Layout.tsx` gives the refactor a clear high-leverage entry point.
+2. Tailwind semantic tokens are already available.
+3. shadcn-style primitive patterns exist and can be expanded.
+4. `ModelColorsContext` proves that the app can support user-scoped visual preferences with local persistence.
+
+### Weaknesses
+
+1. UI primitives are underused.
+2. Feature pages duplicate the same surface and badge formulas instead of consuming variants.
+3. Status semantics are coupled directly to raw colors in files such as `components/featureStatus.ts`.
+4. Very large component files embed too much local styling logic:
+   - `components/SessionInspector.tsx` at `8706` lines
+   - `components/ProjectBoard.tsx` at `4259` lines
+   - `components/Settings.tsx` at `2537` lines
+   - `components/FeatureExecutionWorkbench.tsx` at `2872` lines
+5. Dynamic Tailwind color construction exists in `components/Dashboard.tsx` and should be eliminated before broad theming work.
+
+### Overall Assessment
+
+Architecture quality for large-scale theming refactors is `moderate`, not `high`.
+
+The system is salvageable and already partially prepared, but the current codebase is still operating as a dark theme product with token support on the side, not as a token-driven multi-theme application.
+
+## Feasibility By Delivery Scope
+
+### Add Light/Dark/System Theme Selection
+
+Feasibility: `high`
+
+Rationale:
+
+1. The app can support a `ThemeProvider` at the root.
+2. Existing CSS variable tokens already support a light and dark token base.
+3. `localStorage` persistence patterns already exist elsewhere in the app.
+
+### Refactor The App To Be Theme-System Ready
+
+Feasibility: `high`, but not cheap
+
+Rationale:
+
+1. The work is mostly migration and standardization, not invention.
+2. The largest cost is replacing copied palette formulas with semantic roles and shared components.
+3. Monolithic components increase effort and should be decomposed incrementally during the refactor.
+
+### Let Users Apply Custom UI Themes To The Entire App
+
+Feasibility: `medium`
+
+Rationale:
+
+1. This is straightforward only after the semantic refactor and standard theme modes are complete.
+2. Users should customize token maps and validated presets, not arbitrary CSS injection.
+3. Visualization-specific and data-driven colors need bounded exception rules.
+
+## Light Mode Considerations
+
+The following issues must be addressed before Light Mode can be considered real rather than cosmetic.
+
+1. Remove bootstrap-time forced `.dark` class application.
+2. Make `color-scheme` follow resolved theme mode instead of always being dark.
+3. Replace dark-only scrollbar colors with tokens.
+4. Replace dark-only markdown/content viewer styling with token-backed rules.
+5. Convert shell/layout/background surfaces from palette literals to semantic surface tokens.
+6. Convert chart axes, grids, tooltips, and series defaults to token-backed configuration.
+7. Validate contrast on tables, chips, selected states, hover states, and badges under both themes.
+
+## Mass Style Update Considerations
+
+Mass updates are possible, but the project should avoid naive string replacement.
+
+### Safe High-Leverage Targets
+
+1. Shared shell surfaces in `Layout.tsx`
+2. Repeated panel containers
+3. Shared buttons/inputs/selects/popovers/tooltips
+4. Alert and status badges
+5. Chart wrappers and tooltip/grid defaults
+6. Content viewer and markdown shells
+
+### Risky Targets
+
+1. Very large monolithic files with intertwined logic and styling
+2. Dynamic Tailwind string construction
+3. Data-driven inline colors used for domain visualization
+4. Chart color semantics spread across many files
+
+### Migration Pattern Recommended
+
+1. Introduce semantic aliases and new shared primitives first.
+2. Migrate repeated shells and status states next.
+3. Migrate charts and viewer surfaces centrally.
+4. Only then migrate page-specific edge cases.
+
+## Recommended Delivery Sequence
+
+The correct order is:
+
+1. Theme foundation refactor
+2. Standard theme modes (`dark`, `light`, `system`)
+3. Custom theming
+
+This order matters because custom theming delivered before semantic migration would either:
+
+1. fail to cover much of the app surface, or
+2. force a brittle parallel theming system on top of hard-coded page styles.
+
+## Bottom Line
+
+CCDash should proceed with a theme-system program, but it should be planned as a staged UI-platform refactor rather than a small settings enhancement.
+
+The app already has enough infrastructure to justify the work. The missing piece is consistent adoption of semantic tokens and shared styling primitives across the real product surface.

--- a/docs/shared-content-viewer-developer-reference.md
+++ b/docs/shared-content-viewer-developer-reference.md
@@ -1,0 +1,182 @@
+# Shared Content Viewer Developer Reference
+
+Last updated: 2026-03-19
+
+This reference covers the CCDash-specific shared content viewer wrapper, where it is used, and the configuration assumptions behind the current rendering behavior.
+
+## Goals
+
+- standardize document and file rendering across primary surfaces
+- preserve edit behavior where CCDash already supported writes
+- keep transcript/detail usage selective instead of replacing normal conversational cards
+- align read-only rendering more closely with the SkillMeat parent experience
+
+## Primary files
+
+## Shared wrapper and helpers
+
+- `components/content/UnifiedContentViewer.tsx`
+- `lib/contentViewer.ts`
+- `lib/sessionContentViewer.ts`
+- `src/index.css`
+
+## Consumers
+
+- `components/DocumentModal.tsx`
+- `components/PlanCatalog.tsx`
+- `components/ProjectBoard.tsx`
+- `components/SessionInspector.tsx`
+- `components/content/ProjectFileViewerModal.tsx`
+
+## Backend support for raw session file views
+
+- `backend/routers/codebase.py`
+- `backend/services/codebase_explorer.py`
+
+Session Inspector raw file modals rely on `GET /api/codebase/file-content?path=...`.
+
+Current behavior:
+
+- project-scoped reads are supported
+- current worktree also accepts absolute filesystem paths through the backend helper
+- responses are read-only
+- large files can be truncated before display
+
+## Rendering model
+
+`UnifiedContentViewer` has two main paths:
+
+1. Editing path
+   - delegates to `@miethe/ui/content-viewer` `ContentPane`
+   - preserves existing document edit/start/save/cancel flows
+
+2. Non-editing path
+   - uses a CCDash-side read-only renderer
+   - applies markdown detection, frontmatter separation, and code/text overflow handling
+   - uses shared CSS under `.ccdash-content-viewer`
+
+This split is intentional. It keeps package-based editing behavior while giving CCDash tighter control over read-only rendering quality.
+
+## Mode detection
+
+`lib/contentViewer.ts` resolves the viewer mode with two signals:
+
+- file extension
+- markdown-like content heuristics for read-only views
+
+Markdown-like detection currently looks for signals such as:
+
+- headings
+- blockquotes
+- bullet or ordered lists
+- fenced code blocks
+- tables
+- YAML frontmatter
+
+That allows markdown rendering even when the source does not have a `.md` extension.
+
+## Transcript/detail heuristics
+
+`lib/sessionContentViewer.ts` is responsible for Session Inspector-specific viewer escalation.
+
+Current rules:
+
+- read-tool outputs can render in the viewer when a file path and usable output body exist
+- consistent line-number prefixes are stripped from read-tool output before rendering
+- generic transcript/detail payloads only escalate into the viewer when they are long-form or markdown-like
+- short conversational content remains in the existing transcript cards
+
+Current thresholds:
+
+- character threshold: `600`
+- line threshold: `14`
+
+If these need tuning, update them in `lib/sessionContentViewer.ts` instead of adding per-surface exceptions.
+
+## Styling and configuration
+
+## Tailwind/package scanning
+
+`tailwind.config.js` must continue to scan:
+
+- local app files
+- `./node_modules/@miethe/ui/dist/**/*.js`
+
+Without the package dist glob, package classes can be purged.
+
+## Dark mode
+
+The app expects the root dark class to be active:
+
+- `index.tsx` adds `dark` to `document.documentElement`
+- `src/index.css` defines the semantic token values used by the package and the CCDash wrapper
+
+## CCDash-specific read-only styles
+
+`src/index.css` provides the wrapper styling for:
+
+- markdown headings, paragraphs, lists, tables, blockquotes, and inline code
+- pre/code blocks with horizontal scrolling
+- mode-specific whitespace behavior for code/text panes
+
+These styles intentionally live in CCDash rather than the package so the app can keep its own visual language.
+
+## Usage guidance
+
+Use `UnifiedContentViewer` when:
+
+- the surface should display document or file content in the standard CCDash shell
+- the content may be markdown or markdown-like
+- frontmatter separation should remain consistent with documents and plans
+
+Prefer `DocumentModal` when:
+
+- the item is a typed `PlanDocument`
+- you need document relationships, delivery metadata, or edit/save behavior
+
+Prefer `ProjectFileViewerModal` when:
+
+- the item is a file-backed session row
+- the file is not a typed document
+- the flow should stay read-only
+
+## Example
+
+```tsx
+<UnifiedContentViewer
+  path={doc.filePath}
+  content={doc.content}
+  readOnly={!canEdit}
+  isEditing={isEditing}
+  editedContent={draftContent}
+  onEditStart={handleStartEdit}
+  onEditChange={setDraftContent}
+  onSave={handleSave}
+  onCancel={handleCancelEdit}
+/>
+```
+
+## Validation
+
+Focused coverage currently lives in:
+
+- `components/content/__tests__/UnifiedContentViewer.test.tsx`
+- `lib/__tests__/contentViewer.test.ts`
+- `lib/__tests__/sessionContentViewer.test.ts`
+- `backend/tests/test_codebase_router.py`
+
+Recommended checks after changes:
+
+```bash
+pnpm exec vitest run \
+  lib/__tests__/contentViewer.test.ts \
+  lib/__tests__/sessionContentViewer.test.ts \
+  components/content/__tests__/UnifiedContentViewer.test.tsx
+
+backend/.venv/bin/python -m unittest backend.tests.test_codebase_router
+```
+
+## Known caveats
+
+- Repo-wide `pnpm typecheck` currently includes unrelated example-suite noise; filter by touched files when validating this area.
+- Transcript escalation is heuristic-based by design. If a payload should stay a plain card, prefer tightening the shared thresholds before adding special-case UI logic.

--- a/docs/shared-content-viewer-user-guide.md
+++ b/docs/shared-content-viewer-user-guide.md
@@ -1,0 +1,105 @@
+# Shared Content Viewer User Guide
+
+Last updated: 2026-03-19
+
+This guide explains where the shared content viewer appears in CCDash, what it renders, and what behavior to expect across documents, task sources, and session detail flows.
+
+## What changed
+
+CCDash now uses a common viewer shell for long-form document and file content across the main product surfaces.
+
+The shared viewer now supports:
+
+- formatted markdown rendering for documents, plans, prompts, and other markdown-like content
+- collapsed frontmatter display when YAML frontmatter is present
+- consistent code/text rendering with horizontal scrolling for long lines
+- a lightweight raw file viewer modal for file-backed session rows that are not typed documents
+- transcript/detail-pane escalation into the viewer when content is clearly long-form or markdown-like
+
+## Where you will see it
+
+## Documents (`/plans`)
+
+The shared viewer is used in:
+
+- the folder preview pane in `Plan Catalog`
+- the `Content` tab inside `Document Modal`
+
+What to expect:
+
+- markdown docs render as formatted content instead of raw source text
+- frontmatter is shown separately from the body
+- implementation plans, PRDs, reports, and progress docs share the same visual shell
+
+## Feature Board (`/board`)
+
+The shared viewer is used in the task source dialog for feature tasks.
+
+What to expect:
+
+- markdown task source files render with headings, lists, code fences, and links
+- JSON, TOML, YAML, and source files render in a code-style pane with horizontal scroll for long lines
+
+## Session Inspector (`/sessions`)
+
+The shared viewer appears in three places:
+
+- `Activity` tab: file-backed rows can open in the shared viewer
+- `Files` tab: file rows can open in the shared viewer
+- transcript/detail pane: long-form or markdown-like payloads can switch from plain cards to the shared viewer
+
+Session behavior is intentionally narrow:
+
+- typed linked documents still open in `Document Modal`
+- short conversational transcript messages remain normal transcript cards
+- only file-backed, long-form, or markdown-like detail content escalates into the viewer
+
+## Raw file viewer modal
+
+When a session file row maps to a project file but not to a typed plan document, CCDash opens a lightweight read-only viewer modal.
+
+This modal:
+
+- fetches the current file content through the app backend
+- keeps the file read-only
+- includes a shortcut to open the same file locally in VS Code
+
+## Transcript and prompt rendering
+
+Long prompts and other long-form detail payloads can now render in the shared viewer instead of a raw `<pre>` block.
+
+Examples include:
+
+- expanded task prompts in Session Inspector tool details
+- markdown-like session detail content
+- read-tool outputs that contain structured file content
+
+Read-tool line prefixes are normalized before rendering so the viewer shows the file body instead of transport-specific line-number formatting.
+
+## Editing behavior
+
+Editing remains limited to the document flows that already supported it:
+
+- project plan documents can still be edited from `Document Modal`
+- progress docs remain read-only
+- raw file viewer modal in Session Inspector is read-only
+
+## What the viewer does with different content
+
+- Markdown or markdown-like content: renders as formatted markdown
+- Frontmatter-bearing content: shows frontmatter separately and keeps it out of the body preview
+- Code/text content: renders in a monospace pane with horizontal scrolling for long lines
+- Large files: show a truncation banner when CCDash is only showing a partial preview
+
+## Troubleshooting
+
+1. If markdown still looks raw, confirm you are looking at a viewer surface and not a short plain transcript card.
+2. If a session file row opens locally but not in the viewer, the file may no longer exist or may not be readable from the active project context.
+3. If the viewer looks stale after edits or sync changes, run a cache rescan and reopen the surface.
+
+## Related docs
+
+- `docs/document-entity-user-guide.md`
+- `docs/execution-workbench-user-guide.md`
+- `docs/codebase-explorer-developer-reference.md`
+- `docs/shared-content-viewer-developer-reference.md`

--- a/index.tsx
+++ b/index.tsx
@@ -3,6 +3,9 @@ import ReactDOM from 'react-dom/client';
 import './src/index.css';
 import App from './App';
 
+document.documentElement.classList.add('dark');
+document.body.classList.add('dark');
+
 const rootElement = document.getElementById('root');
 if (!rootElement) {
   throw new Error("Could not find root element to mount to");

--- a/lib/__tests__/contentViewer.test.ts
+++ b/lib/__tests__/contentViewer.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildContentViewerTruncationInfo,
+  getContentViewerExtension,
+  getContentViewerMode,
+  isContentViewerEditable,
+  normalizeContentViewerPath,
+  shouldUseContentViewer,
+} from '../contentViewer';
+
+describe('contentViewer utilities', () => {
+  it('normalizes file paths for viewer usage', () => {
+    expect(normalizeContentViewerPath('./docs\\plans//phase-1.md')).toBe('docs/plans/phase-1.md');
+    expect(normalizeContentViewerPath('')).toBeNull();
+  });
+
+  it('derives extension, mode, and editability', () => {
+    expect(getContentViewerExtension('notes/README.MD')).toBe('.md');
+    expect(getContentViewerMode('notes/README.MD')).toBe('markdown');
+    expect(isContentViewerEditable('notes/README.MD')).toBe(true);
+    expect(getContentViewerMode('artifacts/output.json')).toBe('code');
+    expect(isContentViewerEditable('artifacts/output.json')).toBe(true);
+    expect(getContentViewerMode('logs/output.log')).toBe('text');
+    expect(isContentViewerEditable('logs/output.log')).toBe(false);
+  });
+
+  it('builds truncation info only when needed', () => {
+    expect(buildContentViewerTruncationInfo()).toBeUndefined();
+    expect(
+      buildContentViewerTruncationInfo({
+        truncated: true,
+        originalSize: 2048,
+        fullFileUrl: 'https://example.com/file.md',
+      })
+    ).toEqual({
+      truncated: true,
+      originalSize: 2048,
+      fullFileUrl: 'https://example.com/file.md',
+    });
+  });
+
+  it('allows viewer mode only when a path is present', () => {
+    expect(shouldUseContentViewer(null, 'content')).toBe(false);
+    expect(shouldUseContentViewer('docs/file.md', null)).toBe(true);
+  });
+});

--- a/lib/__tests__/contentViewer.test.ts
+++ b/lib/__tests__/contentViewer.test.ts
@@ -7,6 +7,7 @@ import {
   isContentViewerEditable,
   looksLikeMarkdownContent,
   normalizeContentViewerPath,
+  resolveContentViewerFrontmatter,
   shouldUseContentViewer,
 } from '../contentViewer';
 
@@ -51,5 +52,26 @@ describe('contentViewer utilities', () => {
     expect(looksLikeMarkdownContent('plain text output')).toBe(false);
     expect(getReadOnlyContentViewerMode('logs/output.txt', '# Heading\n\nParagraph')).toBe('markdown');
     expect(getReadOnlyContentViewerMode('logs/output.txt', 'plain text output')).toBe('code');
+  });
+
+  it('prefers raw frontmatter payloads for viewer rendering', () => {
+    expect(resolveContentViewerFrontmatter({
+      title: 'Normalized',
+      raw: {
+        title: 'Original',
+        status: 'draft',
+      },
+    })).toEqual({
+      title: 'Original',
+      status: 'draft',
+    });
+  });
+
+  it('filters empty frontmatter payloads', () => {
+    expect(resolveContentViewerFrontmatter({
+      tags: [],
+      status: '',
+      raw: {},
+    })).toBeNull();
   });
 });

--- a/lib/__tests__/contentViewer.test.ts
+++ b/lib/__tests__/contentViewer.test.ts
@@ -3,7 +3,9 @@ import {
   buildContentViewerTruncationInfo,
   getContentViewerExtension,
   getContentViewerMode,
+  getReadOnlyContentViewerMode,
   isContentViewerEditable,
+  looksLikeMarkdownContent,
   normalizeContentViewerPath,
   shouldUseContentViewer,
 } from '../contentViewer';
@@ -42,5 +44,12 @@ describe('contentViewer utilities', () => {
   it('allows viewer mode only when a path is present', () => {
     expect(shouldUseContentViewer(null, 'content')).toBe(false);
     expect(shouldUseContentViewer('docs/file.md', null)).toBe(true);
+  });
+
+  it('detects markdown-like content for read-only rendering', () => {
+    expect(looksLikeMarkdownContent('# Heading\n\n- one')).toBe(true);
+    expect(looksLikeMarkdownContent('plain text output')).toBe(false);
+    expect(getReadOnlyContentViewerMode('logs/output.txt', '# Heading\n\nParagraph')).toBe('markdown');
+    expect(getReadOnlyContentViewerMode('logs/output.txt', 'plain text output')).toBe('code');
   });
 });

--- a/lib/__tests__/documentFileTree.test.ts
+++ b/lib/__tests__/documentFileTree.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildDocumentFileTree } from '../documentFileTree';
+import type { PlanDocument } from '../../types';
+
+const createDocument = (filePath: string): PlanDocument => ({
+  id: filePath,
+  title: filePath.split('/').pop() || filePath,
+  filePath,
+  canonicalPath: filePath,
+  status: 'active',
+  createdAt: '',
+  updatedAt: '',
+  completedAt: '',
+  lastModified: '',
+  author: '',
+  docType: 'implementation_plan',
+  category: '',
+  docSubtype: '',
+  rootKind: 'project_plans',
+  hasFrontmatter: true,
+  frontmatterType: 'yaml',
+  frontmatter: {
+    tags: [],
+    linkedFeatures: [],
+    linkedFeatureRefs: [],
+    blockedBy: [],
+    linkedSessions: [],
+    linkedTasks: [],
+    lineageChildren: [],
+    relatedFiles: [],
+    commits: [],
+    prs: [],
+    requestLogIds: [],
+    commitRefs: [],
+    prRefs: [],
+    relatedRefs: [],
+    pathRefs: [],
+    slugRefs: [],
+    prdRefs: [],
+    sourceDocuments: [],
+    filesAffected: [],
+    filesModified: [],
+    contextFiles: [],
+    integritySignalRefs: [],
+    fieldKeys: [],
+    raw: {},
+  },
+  metadata: {
+    phase: '',
+    taskCounts: {
+      total: 0,
+      completed: 0,
+      inProgress: 0,
+      blocked: 0,
+    },
+    owners: [],
+    contributors: [],
+    reviewers: [],
+    approvers: [],
+    audience: [],
+    labels: [],
+    blockedBy: [],
+    requestLogIds: [],
+    commitRefs: [],
+    prRefs: [],
+    sourceDocuments: [],
+    filesAffected: [],
+    filesModified: [],
+    contextFiles: [],
+    integritySignalRefs: [],
+    linkedTasks: [],
+    executionEntrypoints: [],
+    linkedFeatureRefs: [],
+    docTypeFields: {},
+    featureSlugHint: '',
+    canonicalPath: filePath,
+  },
+  pathSegments: filePath.split('/'),
+  featureCandidates: [],
+  totalTasks: 0,
+  completedTasks: 0,
+  inProgressTasks: 0,
+  blockedTasks: 0,
+});
+
+describe('buildDocumentFileTree', () => {
+  it('creates a nested file tree sorted by folders before files', () => {
+    const tree = buildDocumentFileTree([
+      createDocument('docs/project_plans/plan-b.md'),
+      createDocument('docs/project_plans/sub/plan-a.md'),
+      createDocument('docs/project_plans/plan-a.md'),
+    ]);
+
+    expect(tree).toEqual([
+      {
+        name: 'docs',
+        path: 'docs',
+        type: 'directory',
+        children: [
+          {
+            name: 'project_plans',
+            path: 'docs/project_plans',
+            type: 'directory',
+            children: [
+              {
+                name: 'sub',
+                path: 'docs/project_plans/sub',
+                type: 'directory',
+                children: [
+                  {
+                    name: 'plan-a.md',
+                    path: 'docs/project_plans/sub/plan-a.md',
+                    type: 'file',
+                  },
+                ],
+              },
+              {
+                name: 'plan-a.md',
+                path: 'docs/project_plans/plan-a.md',
+                type: 'file',
+              },
+              {
+                name: 'plan-b.md',
+                path: 'docs/project_plans/plan-b.md',
+                type: 'file',
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('ignores documents without a usable path', () => {
+    const tree = buildDocumentFileTree([
+      createDocument(''),
+      createDocument('./docs/project_plans/plan.md'),
+    ]);
+
+    expect(tree[0]?.children?.[0]?.children).toEqual([
+      {
+        name: 'plan.md',
+        path: 'docs/project_plans/plan.md',
+        type: 'file',
+      },
+    ]);
+  });
+});

--- a/lib/__tests__/sessionContentViewer.test.ts
+++ b/lib/__tests__/sessionContentViewer.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { getInlineContentViewerPayload } from '../sessionContentViewer';
+import { getInlineContentViewerPayload, getTranscriptContentViewerPayload } from '../sessionContentViewer';
 
 describe('sessionContentViewer helpers', () => {
   it('returns inline viewer payload for raw text output', () => {
@@ -27,5 +27,24 @@ describe('sessionContentViewer helpers', () => {
   it('returns null when path or content are missing', () => {
     expect(getInlineContentViewerPayload('', 'hello')).toBeNull();
     expect(getInlineContentViewerPayload('docs/plan.md', '')).toBeNull();
+  });
+
+  it('strips consistent read-tool line prefixes', () => {
+    expect(getInlineContentViewerPayload('docs/plan.md', '1 | # Plan\n2 | - item\n3 | text')).toEqual({
+      path: 'docs/plan.md',
+      content: '# Plan\n- item\ntext',
+    });
+  });
+
+  it('uses the shared viewer for long transcript content', () => {
+    const payload = getTranscriptContentViewerPayload(
+      'log-123',
+      '# Heading\n\n' + 'Paragraph text.\n'.repeat(20),
+    );
+
+    expect(payload).toEqual({
+      path: 'transcript/log-123.md',
+      content: '# Heading\n\n' + 'Paragraph text.\n'.repeat(20),
+    });
   });
 });

--- a/lib/__tests__/sessionContentViewer.test.ts
+++ b/lib/__tests__/sessionContentViewer.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { getInlineContentViewerPayload } from '../sessionContentViewer';
+
+describe('sessionContentViewer helpers', () => {
+  it('returns inline viewer payload for raw text output', () => {
+    expect(getInlineContentViewerPayload('./docs/plan.md', '# Plan\n')).toEqual({
+      path: 'docs/plan.md',
+      content: '# Plan\n',
+    });
+  });
+
+  it('extracts nested content fields from structured tool output', () => {
+    expect(
+      getInlineContentViewerPayload(
+        'docs/plan.md',
+        JSON.stringify({
+          content: '# Loaded\n',
+        }),
+      ),
+    ).toEqual({
+      path: 'docs/plan.md',
+      content: '# Loaded\n',
+    });
+  });
+
+  it('returns null when path or content are missing', () => {
+    expect(getInlineContentViewerPayload('', 'hello')).toBeNull();
+    expect(getInlineContentViewerPayload('docs/plan.md', '')).toBeNull();
+  });
+});

--- a/lib/contentViewer.ts
+++ b/lib/contentViewer.ts
@@ -16,6 +16,15 @@ const VIEWER_EDITABLE_EXTENSIONS = new Set([
 ]);
 
 const VIEWER_MARKDOWN_EXTENSIONS = new Set(['.md', '.markdown']);
+const MARKDOWN_SIGNAL_PATTERNS = [
+  /^#{1,6}\s+/m,
+  /^>\s+/m,
+  /^[-*+]\s+/m,
+  /^\d+\.\s+/m,
+  /```[\s\S]*?```/m,
+  /^\|.+\|\s*$/m,
+  /^---\n[\s\S]+?\n---\n?/m,
+];
 
 export type ContentViewerMode = 'markdown' | 'text' | 'code' | 'binary';
 
@@ -51,6 +60,27 @@ export const getContentViewerMode = (path: string | null | undefined): ContentVi
   if (VIEWER_EDITABLE_EXTENSIONS.has(extension)) return 'code';
   if (!extension) return 'text';
   return 'text';
+};
+
+export const looksLikeMarkdownContent = (content: string | null | undefined): boolean => {
+  const text = String(content || '').trim();
+  if (!text) return false;
+
+  return MARKDOWN_SIGNAL_PATTERNS.some(pattern => pattern.test(text));
+};
+
+export const getReadOnlyContentViewerMode = (
+  path: string | null | undefined,
+  content: string | null | undefined,
+): ContentViewerMode => {
+  const modeFromPath = getContentViewerMode(path);
+  if (modeFromPath === 'markdown') {
+    return 'markdown';
+  }
+  if (looksLikeMarkdownContent(content)) {
+    return 'markdown';
+  }
+  return modeFromPath;
 };
 
 export const isContentViewerEditable = (path: string | null | undefined): boolean => {

--- a/lib/contentViewer.ts
+++ b/lib/contentViewer.ts
@@ -104,3 +104,28 @@ export const buildContentViewerTruncationInfo = (
     fullFileUrl: input.fullFileUrl,
   };
 };
+
+export const resolveContentViewerFrontmatter = (
+  frontmatter: Record<string, unknown> | null | undefined,
+): Record<string, unknown> | null => {
+  if (!frontmatter || typeof frontmatter !== 'object' || Array.isArray(frontmatter)) {
+    return null;
+  }
+
+  const rawFrontmatter = frontmatter.raw;
+  const candidate = (
+    rawFrontmatter
+    && typeof rawFrontmatter === 'object'
+    && !Array.isArray(rawFrontmatter)
+  ) ? rawFrontmatter as Record<string, unknown> : frontmatter;
+
+  const entries = Object.entries(candidate).filter(([key, value]) => {
+    if (key === 'raw') return false;
+    if (value === null || value === undefined) return false;
+    if (typeof value === 'string') return value.trim().length > 0;
+    if (Array.isArray(value)) return value.length > 0;
+    return true;
+  });
+
+  return entries.length > 0 ? Object.fromEntries(entries) : null;
+};

--- a/lib/contentViewer.ts
+++ b/lib/contentViewer.ts
@@ -1,0 +1,76 @@
+import type { TruncationInfo } from '@miethe/ui/content-viewer';
+
+const VIEWER_EDITABLE_EXTENSIONS = new Set([
+  '.md',
+  '.markdown',
+  '.txt',
+  '.json',
+  '.ts',
+  '.tsx',
+  '.js',
+  '.jsx',
+  '.py',
+  '.yml',
+  '.yaml',
+  '.toml',
+]);
+
+const VIEWER_MARKDOWN_EXTENSIONS = new Set(['.md', '.markdown']);
+
+export type ContentViewerMode = 'markdown' | 'text' | 'code' | 'binary';
+
+export interface ContentViewerTruncationInput {
+  truncated?: boolean;
+  originalSize?: number;
+  fullFileUrl?: string;
+}
+
+export const normalizeContentViewerPath = (path: string | null | undefined): string | null => {
+  const normalized = String(path || '')
+    .replace(/\\/g, '/')
+    .replace(/^(?:\.\/|\/)+/, '')
+    .replace(/\/+/g, '/')
+    .trim();
+
+  return normalized.length > 0 ? normalized : null;
+};
+
+export const getContentViewerExtension = (path: string | null | undefined): string => {
+  const normalizedPath = normalizeContentViewerPath(path);
+  if (!normalizedPath) return '';
+
+  const filename = normalizedPath.split('/').pop() || '';
+  const lastDot = filename.lastIndexOf('.');
+  if (lastDot <= 0) return '';
+  return filename.slice(lastDot).toLowerCase();
+};
+
+export const getContentViewerMode = (path: string | null | undefined): ContentViewerMode => {
+  const extension = getContentViewerExtension(path);
+  if (VIEWER_MARKDOWN_EXTENSIONS.has(extension)) return 'markdown';
+  if (VIEWER_EDITABLE_EXTENSIONS.has(extension)) return 'code';
+  if (!extension) return 'text';
+  return 'text';
+};
+
+export const isContentViewerEditable = (path: string | null | undefined): boolean => {
+  const extension = getContentViewerExtension(path);
+  return extension ? VIEWER_EDITABLE_EXTENSIONS.has(extension) : false;
+};
+
+export const shouldUseContentViewer = (path: string | null | undefined, content: string | null | undefined): boolean => {
+  if (!normalizeContentViewerPath(path)) return false;
+  if (typeof content === 'string' && content.trim().length > 0) return true;
+  return true;
+};
+
+export const buildContentViewerTruncationInfo = (
+  input?: ContentViewerTruncationInput | TruncationInfo | null
+): TruncationInfo | undefined => {
+  if (!input?.truncated) return undefined;
+  return {
+    truncated: true,
+    originalSize: typeof input.originalSize === 'number' ? input.originalSize : undefined,
+    fullFileUrl: input.fullFileUrl,
+  };
+};

--- a/lib/documentFileTree.ts
+++ b/lib/documentFileTree.ts
@@ -1,0 +1,71 @@
+import type { FileNode } from '@miethe/ui';
+
+import type { PlanDocument } from '../types';
+
+const compareNodes = (left: FileNode, right: FileNode): number => {
+  if (left.type !== right.type) {
+    return left.type === 'directory' ? -1 : 1;
+  }
+  return left.name.localeCompare(right.name);
+};
+
+const sortTree = (nodes: FileNode[]): FileNode[] => (
+  nodes
+    .map((node) => (
+      node.type === 'directory' && node.children
+        ? { ...node, children: sortTree(node.children) }
+        : node
+    ))
+    .sort(compareNodes)
+);
+
+export const buildDocumentFileTree = (documents: PlanDocument[]): FileNode[] => {
+  const root: FileNode[] = [];
+
+  documents.forEach((document) => {
+    const normalizedPath = String(document.filePath || document.canonicalPath || '')
+      .replace(/\\/g, '/')
+      .replace(/^\.?\//, '')
+      .trim();
+
+    if (!normalizedPath) {
+      return;
+    }
+
+    const parts = normalizedPath.split('/').filter(Boolean);
+    let currentLevel = root;
+
+    parts.forEach((part, index) => {
+      const nodePath = parts.slice(0, index + 1).join('/');
+      const isFile = index === parts.length - 1;
+      const existingNode = currentLevel.find((node) => node.path === nodePath);
+
+      if (existingNode) {
+        if (existingNode.type === 'directory' && existingNode.children) {
+          currentLevel = existingNode.children;
+        }
+        return;
+      }
+
+      const nextNode: FileNode = isFile
+        ? {
+            name: part,
+            path: nodePath,
+            type: 'file',
+          }
+        : {
+            name: part,
+            path: nodePath,
+            type: 'directory',
+            children: [],
+          };
+
+      currentLevel.push(nextNode);
+      if (nextNode.type === 'directory' && nextNode.children) {
+        currentLevel = nextNode.children;
+      }
+    });
+  });
+
+  return sortTree(root);
+};

--- a/lib/sessionContentViewer.ts
+++ b/lib/sessionContentViewer.ts
@@ -1,9 +1,12 @@
-import { normalizeContentViewerPath } from './contentViewer';
+import { looksLikeMarkdownContent, normalizeContentViewerPath } from './contentViewer';
 
 export interface InlineContentViewerPayload {
   path: string;
   content: string;
 }
+
+const TRANSCRIPT_CONTENT_VIEWER_CHAR_THRESHOLD = 600;
+const TRANSCRIPT_CONTENT_VIEWER_LINE_THRESHOLD = 14;
 
 const extractStructuredOutputContent = (rawOutput: string): string | null => {
   const raw = String(rawOutput || '');
@@ -34,18 +37,65 @@ const extractStructuredOutputContent = (rawOutput: string): string | null => {
   return raw;
 };
 
+const stripLinePrefixes = (content: string): string => {
+  const lines = content.split('\n');
+  const nonEmptyLines = lines.filter(line => line.trim().length > 0);
+  if (nonEmptyLines.length === 0) return content;
+
+  const prefixedLinePattern = /^\s*\d+(?:\s*[|:]\s|\t)/;
+  const prefixedCount = nonEmptyLines.filter(line => prefixedLinePattern.test(line)).length;
+  if (prefixedCount / nonEmptyLines.length < 0.6) {
+    return content;
+  }
+
+  return lines.map(line => line.replace(prefixedLinePattern, '')).join('\n');
+};
+
+const shouldUseTranscriptContentViewer = (content: string): boolean => {
+  const trimmed = content.trim();
+  if (!trimmed) return false;
+  if (looksLikeMarkdownContent(trimmed)) return true;
+  if (trimmed.length >= TRANSCRIPT_CONTENT_VIEWER_CHAR_THRESHOLD) return true;
+  if (trimmed.split(/\r?\n/).length >= TRANSCRIPT_CONTENT_VIEWER_LINE_THRESHOLD) return true;
+  return false;
+};
+
+const buildSyntheticTranscriptPath = (logId: string, content: string): string => {
+  const safeId = String(logId || 'log')
+    .replace(/[^a-zA-Z0-9_-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'log';
+
+  return `transcript/${safeId}.${looksLikeMarkdownContent(content) ? 'md' : 'txt'}`;
+};
+
 export const getInlineContentViewerPayload = (
   filePath: string | null | undefined,
   rawOutput: string | null | undefined,
 ): InlineContentViewerPayload | null => {
   const path = normalizeContentViewerPath(filePath);
-  const content = extractStructuredOutputContent(String(rawOutput || ''));
+  const content = stripLinePrefixes(extractStructuredOutputContent(String(rawOutput || '')) || '');
   if (!path || !content) {
     return null;
   }
 
   return {
     path,
+    content,
+  };
+};
+
+export const getTranscriptContentViewerPayload = (
+  logId: string,
+  rawContent: string | null | undefined,
+): InlineContentViewerPayload | null => {
+  const content = extractStructuredOutputContent(String(rawContent || ''));
+  if (!content || !shouldUseTranscriptContentViewer(content)) {
+    return null;
+  }
+
+  return {
+    path: buildSyntheticTranscriptPath(logId, content),
     content,
   };
 };

--- a/lib/sessionContentViewer.ts
+++ b/lib/sessionContentViewer.ts
@@ -1,0 +1,51 @@
+import { normalizeContentViewerPath } from './contentViewer';
+
+export interface InlineContentViewerPayload {
+  path: string;
+  content: string;
+}
+
+const extractStructuredOutputContent = (rawOutput: string): string | null => {
+  const raw = String(rawOutput || '');
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (typeof parsed === 'string' && parsed.trim()) {
+      return parsed;
+    }
+    if (parsed && typeof parsed === 'object') {
+      const record = parsed as Record<string, unknown>;
+      if (typeof record.content === 'string' && record.content.trim()) {
+        return record.content;
+      }
+      if (typeof record.stdout === 'string' && record.stdout.trim()) {
+        return record.stdout;
+      }
+      if (typeof record.text === 'string' && record.text.trim()) {
+        return record.text;
+      }
+    }
+  } catch {
+    // Fall back to treating the output as raw text.
+  }
+
+  return raw;
+};
+
+export const getInlineContentViewerPayload = (
+  filePath: string | null | undefined,
+  rawOutput: string | null | undefined,
+): InlineContentViewerPayload | null => {
+  const path = normalizeContentViewerPath(filePath);
+  const content = extractStructuredOutputContent(String(rawOutput || ''));
+  if (!path || !content) {
+    return null;
+  }
+
+  return {
+    path,
+    content,
+  };
+};

--- a/services/codebase.ts
+++ b/services/codebase.ts
@@ -1,0 +1,21 @@
+export interface CodebaseFileContentResponse {
+  filePath: string;
+  absolutePath: string;
+  content: string;
+  sizeBytes: number;
+  truncated: boolean;
+  originalSize?: number | null;
+}
+
+const API_BASE = '/api/codebase';
+
+export async function getCodebaseFileContent(filePath: string): Promise<CodebaseFileContentResponse> {
+  const params = new URLSearchParams({
+    path: filePath,
+  });
+  const res = await fetch(`${API_BASE}/file-content?${params.toString()}`);
+  if (!res.ok) {
+    throw new Error(`Failed to load file content (${res.status})`);
+  }
+  return res.json();
+}

--- a/src/index.css
+++ b/src/index.css
@@ -85,3 +85,146 @@ body {
     --chart-5: 340 75% 55%;
   }
 }
+
+@layer components {
+  .ccdash-content-viewer .ccdash-markdown {
+    color: rgb(226 232 240);
+    line-height: 1.75;
+  }
+
+  .ccdash-content-viewer .ccdash-markdown > :first-child {
+    margin-top: 0;
+  }
+
+  .ccdash-content-viewer .ccdash-markdown > :last-child {
+    margin-bottom: 0;
+  }
+
+  .ccdash-content-viewer .ccdash-markdown h1,
+  .ccdash-content-viewer .ccdash-markdown h2,
+  .ccdash-content-viewer .ccdash-markdown h3,
+  .ccdash-content-viewer .ccdash-markdown h4,
+  .ccdash-content-viewer .ccdash-markdown h5,
+  .ccdash-content-viewer .ccdash-markdown h6 {
+    color: rgb(248 250 252);
+    font-weight: 700;
+    line-height: 1.25;
+    margin-top: 1.5rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .ccdash-content-viewer .ccdash-markdown h1 {
+    font-size: 1.5rem;
+  }
+
+  .ccdash-content-viewer .ccdash-markdown h2 {
+    font-size: 1.25rem;
+  }
+
+  .ccdash-content-viewer .ccdash-markdown h3 {
+    font-size: 1.125rem;
+  }
+
+  .ccdash-content-viewer .ccdash-markdown p,
+  .ccdash-content-viewer .ccdash-markdown ul,
+  .ccdash-content-viewer .ccdash-markdown ol,
+  .ccdash-content-viewer .ccdash-markdown blockquote,
+  .ccdash-content-viewer .ccdash-markdown pre,
+  .ccdash-content-viewer .ccdash-markdown table {
+    margin-top: 0.875rem;
+    margin-bottom: 0.875rem;
+  }
+
+  .ccdash-content-viewer .ccdash-markdown ul,
+  .ccdash-content-viewer .ccdash-markdown ol {
+    padding-left: 1.5rem;
+  }
+
+  .ccdash-content-viewer .ccdash-markdown ul {
+    list-style: disc;
+  }
+
+  .ccdash-content-viewer .ccdash-markdown ol {
+    list-style: decimal;
+  }
+
+  .ccdash-content-viewer .ccdash-markdown li + li {
+    margin-top: 0.25rem;
+  }
+
+  .ccdash-content-viewer .ccdash-markdown a {
+    color: rgb(129 140 248);
+    text-decoration: underline;
+    text-underline-offset: 0.18em;
+  }
+
+  .ccdash-content-viewer .ccdash-markdown strong {
+    color: rgb(248 250 252);
+    font-weight: 700;
+  }
+
+  .ccdash-content-viewer .ccdash-markdown blockquote {
+    border-left: 3px solid rgb(79 70 229 / 0.55);
+    background: rgb(15 23 42 / 0.65);
+    color: rgb(191 219 254);
+    padding: 0.875rem 1rem;
+    border-radius: 0.75rem;
+  }
+
+  .ccdash-content-viewer .ccdash-markdown code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  }
+
+  .ccdash-content-viewer .ccdash-markdown :not(pre) > code {
+    background: rgb(15 23 42 / 0.9);
+    color: rgb(191 219 254);
+    border: 1px solid rgb(51 65 85);
+    border-radius: 0.4rem;
+    padding: 0.15rem 0.35rem;
+    font-size: 0.85em;
+  }
+
+  .ccdash-content-viewer .ccdash-markdown pre {
+    overflow-x: auto;
+    background: rgb(2 6 23 / 0.95);
+    border: 1px solid rgb(30 41 59);
+    border-radius: 0.9rem;
+    padding: 1rem;
+    color: rgb(226 232 240);
+  }
+
+  .ccdash-content-viewer .ccdash-markdown pre code {
+    display: block;
+    min-width: max-content;
+    white-space: pre;
+    word-break: normal;
+    overflow-wrap: normal;
+  }
+
+  .ccdash-content-viewer .ccdash-markdown table {
+    width: 100%;
+    border-collapse: collapse;
+    overflow: hidden;
+    border-radius: 0.9rem;
+    border: 1px solid rgb(30 41 59);
+  }
+
+  .ccdash-content-viewer .ccdash-markdown thead {
+    background: rgb(15 23 42 / 0.92);
+  }
+
+  .ccdash-content-viewer .ccdash-markdown th,
+  .ccdash-content-viewer .ccdash-markdown td {
+    border-bottom: 1px solid rgb(30 41 59);
+    padding: 0.7rem 0.85rem;
+    text-align: left;
+    vertical-align: top;
+  }
+
+  .ccdash-content-viewer[data-content-viewer-mode='code'] pre,
+  .ccdash-content-viewer[data-content-viewer-mode='text'] pre {
+    white-space: pre;
+    word-break: normal;
+    overflow-wrap: normal;
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -2,9 +2,16 @@
 @tailwind components;
 @tailwind utilities;
 
+html {
+  min-height: 100%;
+  background-color: hsl(var(--background));
+  color-scheme: dark;
+}
+
 body {
-  background-color: #020617; /* slate-950 */
-  color: #e2e8f0; /* slate-200 */
+  min-height: 100%;
+  background-color: hsl(var(--background));
+  color: hsl(var(--foreground));
 }
 
 /* Custom Scrollbar for dashboard feel */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,13 +2,14 @@
 export default {
     content: [
         "./index.html",
+        "./node_modules/@miethe/ui/dist/**/*.js",
         "./components/**/*.{tsx,ts}",
         "./contexts/**/*.{tsx,ts}",
         "./services/**/*.ts",
         "./App.tsx",
         "./index.tsx",
     ],
-    darkMode: ['class', "class"],
+    darkMode: ['class'],
     theme: {
     	extend: {
     		colors: {


### PR DESCRIPTION
## Summary
- replace remaining document and file-backed panes with the shared content viewer across documents, plans, task sources, and session/file modals
- preserve YAML frontmatter when editing plan documents and surface parsed frontmatter in shared viewer panes even when document bodies are stored separately
- swap Plan Catalog folder mode to the packaged `FileTree` with a document-tree adapter and add supporting viewer utilities/tests
- update implementation/progress docs, viewer references, and related theming/readme guidance included in this branch

## Testing
- `pnpm exec vitest run components/content/__tests__/UnifiedContentViewer.test.tsx lib/__tests__/contentViewer.test.ts lib/__tests__/documentFileTree.test.ts --exclude='examples/skillmeat/ui/src/**'`
- `backend/.venv/bin/python -m unittest backend.tests.test_documents_router -v`
- `pnpm typecheck` fails in pre-existing `examples/skillmeat/ui` test files due to missing Jest/jsdom/testing-library types