### PR TITLE
Add live-ingest source path canonicalization hardening

### DIFF
--- a/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-1-progress.md
+++ b/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-1-progress.md
@@ -16,10 +16,10 @@ plan_ref: docs/project_plans/implementation_plans/infrastructure/live-ingest-sou
 commit_refs: []
 pr_refs: []
 execution_model: task-scoped
-overall_progress: 33
+overall_progress: 67
 completion_estimate: on-track
 total_tasks: 3
-completed_tasks: 1
+completed_tasks: 2
 in_progress_tasks: 0
 blocked_tasks: 0
 at_risk_tasks: 0
@@ -40,7 +40,7 @@ tasks:
   priority: high
 - id: SRC-002
   description: Add a helper that maps host and container aliases to a stable source key before repository lookup/write.
-  status: pending
+  status: completed
   assigned_to:
   - backend-architect
   - data-layer-expert
@@ -76,10 +76,11 @@ success_criteria:
 - The helper does not require a live container runtime.
 files_modified:
 - backend/services/source_identity.py
+- backend/tests/test_source_identity.py
 - .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-1-progress.md
 - .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-2-progress.md
 - docs/project_plans/implementation_plans/infrastructure/live-ingest-source-path-canonicalization-hardening-v1.md
-progress: 33
+progress: 67
 ---
 
 # live-ingest-source-path-canonicalization-hardening-v1 - Phase 1
@@ -90,4 +91,4 @@ Define the canonical filesystem source identity contract before implementing ali
 
 ## Current Status
 
-`SRC-001` is complete. `SRC-002` and `SRC-003` remain pending and no sync engine wiring has been added.
+`SRC-001` and `SRC-002` are complete. `SRC-003` remains pending and no sync engine wiring has been added.

--- a/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-1-progress.md
+++ b/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-1-progress.md
@@ -1,0 +1,93 @@
+---
+type: progress
+schema_version: 2
+doc_type: progress
+feature_slug: live-ingest-source-path-canonicalization-hardening
+phase: 1
+phase_title: Source Identity Contract
+title: 'live-ingest-source-path-canonicalization-hardening-v1 - Phase 1: Source Identity Contract'
+status: in_progress
+started: '2026-05-04'
+completed: null
+created: '2026-05-04'
+updated: '2026-05-04'
+prd_ref: null
+plan_ref: docs/project_plans/implementation_plans/infrastructure/live-ingest-source-path-canonicalization-hardening-v1.md
+commit_refs: []
+pr_refs: []
+execution_model: task-scoped
+overall_progress: 33
+completion_estimate: on-track
+total_tasks: 3
+completed_tasks: 1
+in_progress_tasks: 0
+blocked_tasks: 0
+at_risk_tasks: 0
+owners:
+- backend-architect
+- data-layer-expert
+contributors:
+- codex
+tasks:
+- id: SRC-001
+  description: Define a single source identity contract for filesystem-derived session, document, progress, and test files.
+  status: completed
+  assigned_to:
+  - backend-architect
+  - data-layer-expert
+  dependencies: []
+  estimated_effort: 1 pt
+  priority: high
+- id: SRC-002
+  description: Add a helper that maps host and container aliases to a stable source key before repository lookup/write.
+  status: pending
+  assigned_to:
+  - backend-architect
+  - data-layer-expert
+  dependencies:
+  - SRC-001
+  estimated_effort: 2 pts
+  priority: high
+- id: SRC-003
+  description: Cover symlinks, non-mounted paths, optional mount slots, unrelated projects, and paths outside known roots.
+  status: pending
+  assigned_to:
+  - backend-architect
+  - data-layer-expert
+  dependencies:
+  - SRC-002
+  estimated_effort: 1 pt
+  priority: high
+parallelization:
+  batch_1:
+  - SRC-001
+  batch_2:
+  - SRC-002
+  batch_3:
+  - SRC-003
+  critical_path:
+  - SRC-001
+  - SRC-002
+  - SRC-003
+blockers: []
+success_criteria:
+- Contract document or code comments identify canonical inputs, outputs, collision behavior, and rollout constraints.
+- Canonicalization is deterministic and side-effect free.
+- The helper does not require a live container runtime.
+files_modified:
+- backend/services/source_identity.py
+- .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-1-progress.md
+- .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-2-progress.md
+- docs/project_plans/implementation_plans/infrastructure/live-ingest-source-path-canonicalization-hardening-v1.md
+progress: 33
+---
+
+# live-ingest-source-path-canonicalization-hardening-v1 - Phase 1
+
+## Objective
+
+Define the canonical filesystem source identity contract before implementing alias resolution or ingest write-boundary changes.
+
+## Current Status
+
+`SRC-001` is complete. `SRC-002` and `SRC-003` remain pending and no sync engine wiring has been added.

--- a/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-1-progress.md
+++ b/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-1-progress.md
@@ -6,9 +6,9 @@ feature_slug: live-ingest-source-path-canonicalization-hardening
 phase: 1
 phase_title: Source Identity Contract
 title: 'live-ingest-source-path-canonicalization-hardening-v1 - Phase 1: Source Identity Contract'
-status: in_progress
+status: completed
 started: '2026-05-04'
-completed: null
+completed: '2026-05-04'
 created: '2026-05-04'
 updated: '2026-05-04'
 prd_ref: null
@@ -16,10 +16,10 @@ plan_ref: docs/project_plans/implementation_plans/infrastructure/live-ingest-sou
 commit_refs: []
 pr_refs: []
 execution_model: task-scoped
-overall_progress: 67
-completion_estimate: on-track
+overall_progress: 100
+completion_estimate: complete
 total_tasks: 3
-completed_tasks: 2
+completed_tasks: 3
 in_progress_tasks: 0
 blocked_tasks: 0
 at_risk_tasks: 0
@@ -50,7 +50,7 @@ tasks:
   priority: high
 - id: SRC-003
   description: Cover symlinks, non-mounted paths, optional mount slots, unrelated projects, and paths outside known roots.
-  status: pending
+  status: completed
   assigned_to:
   - backend-architect
   - data-layer-expert
@@ -80,7 +80,7 @@ files_modified:
 - .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-1-progress.md
 - .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-2-progress.md
 - docs/project_plans/implementation_plans/infrastructure/live-ingest-source-path-canonicalization-hardening-v1.md
-progress: 67
+progress: 100
 ---
 
 # live-ingest-source-path-canonicalization-hardening-v1 - Phase 1
@@ -91,4 +91,4 @@ Define the canonical filesystem source identity contract before implementing ali
 
 ## Current Status
 
-`SRC-001` and `SRC-002` are complete. `SRC-003` remains pending and no sync engine wiring has been added.
+Phase 1 is complete. The source identity contract, helper, and alias/collision tests are in place; no sync engine wiring has been added.

--- a/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-1-progress.md
+++ b/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-1-progress.md
@@ -13,7 +13,10 @@ created: '2026-05-04'
 updated: '2026-05-04'
 prd_ref: null
 plan_ref: docs/project_plans/implementation_plans/infrastructure/live-ingest-source-path-canonicalization-hardening-v1.md
-commit_refs: []
+commit_refs:
+- 60d5b4a
+- 79ad357
+- 462019e
 pr_refs: []
 execution_model: task-scoped
 overall_progress: 100

--- a/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-2-progress.md
+++ b/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-2-progress.md
@@ -16,10 +16,10 @@ plan_ref: docs/project_plans/implementation_plans/infrastructure/live-ingest-sou
 commit_refs: []
 pr_refs: []
 execution_model: task-scoped
-overall_progress: 50
+overall_progress: 75
 completion_estimate: on-track
 total_tasks: 4
-completed_tasks: 2
+completed_tasks: 3
 in_progress_tasks: 0
 blocked_tasks: 0
 at_risk_tasks: 0
@@ -50,7 +50,7 @@ tasks:
   priority: high
 - id: ING-003
   description: Ensure delete/replace boundaries do not duplicate rows when the same physical file appears through an alias path.
-  status: pending
+  status: completed
   assigned_to:
   - python-backend-engineer
   - data-layer-expert
@@ -89,9 +89,10 @@ success_criteria:
 - Existing Postgres repository tests still pass.
 files_modified:
 - backend/db/sync_engine.py
+- backend/tests/test_file_watcher.py
 - backend/tests/test_sync_engine_linking.py
 - .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-2-progress.md
-progress: 50
+progress: 75
 ---
 
 # live-ingest-source-path-canonicalization-hardening-v1 - Phase 2
@@ -102,4 +103,4 @@ Apply canonical source keys at ingest lookup/write/delete boundaries after the P
 
 ## Current Status
 
-`ING-001` and `ING-002` are complete. Sync-state and session source-file boundaries now use canonical source identity keys while preserving the observed source path in session forensics.
+`ING-001`, `ING-002`, and `ING-003` are complete. Alias-path session reingest now keeps replace-scoped tables stable with canonical source identity keys.

--- a/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-2-progress.md
+++ b/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-2-progress.md
@@ -16,10 +16,10 @@ plan_ref: docs/project_plans/implementation_plans/infrastructure/live-ingest-sou
 commit_refs: []
 pr_refs: []
 execution_model: task-scoped
-overall_progress: 25
+overall_progress: 50
 completion_estimate: on-track
 total_tasks: 4
-completed_tasks: 1
+completed_tasks: 2
 in_progress_tasks: 0
 blocked_tasks: 0
 at_risk_tasks: 0
@@ -40,7 +40,7 @@ tasks:
   priority: high
 - id: ING-002
   description: Normalize sessions.source_file at write boundaries or add an explicit canonical source column while preserving display/debug compatibility.
-  status: pending
+  status: completed
   assigned_to:
   - python-backend-engineer
   - data-layer-expert
@@ -91,7 +91,7 @@ files_modified:
 - backend/db/sync_engine.py
 - backend/tests/test_sync_engine_linking.py
 - .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-2-progress.md
-progress: 25
+progress: 50
 ---
 
 # live-ingest-source-path-canonicalization-hardening-v1 - Phase 2
@@ -102,4 +102,4 @@ Apply canonical source keys at ingest lookup/write/delete boundaries after the P
 
 ## Current Status
 
-`ING-001` is complete. Sync-state lookup, upsert, and delete boundaries now use canonical source identity keys; session source persistence remains pending for `ING-002`.
+`ING-001` and `ING-002` are complete. Sync-state and session source-file boundaries now use canonical source identity keys while preserving the observed source path in session forensics.

--- a/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-2-progress.md
+++ b/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-2-progress.md
@@ -13,7 +13,11 @@ created: '2026-05-04'
 updated: '2026-05-04'
 prd_ref: null
 plan_ref: docs/project_plans/implementation_plans/infrastructure/live-ingest-source-path-canonicalization-hardening-v1.md
-commit_refs: []
+commit_refs:
+- 9196922
+- 7e57c7f
+- 0577e4c
+- f0c106a
 pr_refs: []
 execution_model: task-scoped
 overall_progress: 100

--- a/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-2-progress.md
+++ b/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-2-progress.md
@@ -6,8 +6,8 @@ feature_slug: live-ingest-source-path-canonicalization-hardening
 phase: 2
 phase_title: Ingest Path Canonicalization
 title: 'live-ingest-source-path-canonicalization-hardening-v1 - Phase 2: Ingest Path Canonicalization'
-status: pending
-started: null
+status: in_progress
+started: '2026-05-04'
 completed: null
 created: '2026-05-04'
 updated: '2026-05-04'
@@ -16,10 +16,10 @@ plan_ref: docs/project_plans/implementation_plans/infrastructure/live-ingest-sou
 commit_refs: []
 pr_refs: []
 execution_model: task-scoped
-overall_progress: 0
-completion_estimate: not-started
+overall_progress: 25
+completion_estimate: on-track
 total_tasks: 4
-completed_tasks: 0
+completed_tasks: 1
 in_progress_tasks: 0
 blocked_tasks: 0
 at_risk_tasks: 0
@@ -30,7 +30,7 @@ contributors: []
 tasks:
 - id: ING-001
   description: Update sync state lookup, upsert, and delete usage sites so startup sync checks canonical source identity before deciding a file is new.
-  status: pending
+  status: completed
   assigned_to:
   - python-backend-engineer
   - data-layer-expert
@@ -82,14 +82,16 @@ parallelization:
   - ING-001
   - ING-003
   - ING-004
-blockers:
-- Phase 2 depends on SRC-002 helper implementation, which is intentionally pending after SRC-001.
+blockers: []
 success_criteria:
 - A second startup under container paths skips files already synced under host paths when content/mtime is unchanged.
 - Existing local SQLite tests still pass.
 - Existing Postgres repository tests still pass.
-files_modified: []
-progress: 0
+files_modified:
+- backend/db/sync_engine.py
+- backend/tests/test_sync_engine_linking.py
+- .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-2-progress.md
+progress: 25
 ---
 
 # live-ingest-source-path-canonicalization-hardening-v1 - Phase 2
@@ -100,4 +102,4 @@ Apply canonical source keys at ingest lookup/write/delete boundaries after the P
 
 ## Current Status
 
-Phase 2 has not started.
+`ING-001` is complete. Sync-state lookup, upsert, and delete boundaries now use canonical source identity keys; session source persistence remains pending for `ING-002`.

--- a/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-2-progress.md
+++ b/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-2-progress.md
@@ -6,9 +6,9 @@ feature_slug: live-ingest-source-path-canonicalization-hardening
 phase: 2
 phase_title: Ingest Path Canonicalization
 title: 'live-ingest-source-path-canonicalization-hardening-v1 - Phase 2: Ingest Path Canonicalization'
-status: in_progress
+status: completed
 started: '2026-05-04'
-completed: null
+completed: '2026-05-04'
 created: '2026-05-04'
 updated: '2026-05-04'
 prd_ref: null
@@ -16,10 +16,10 @@ plan_ref: docs/project_plans/implementation_plans/infrastructure/live-ingest-sou
 commit_refs: []
 pr_refs: []
 execution_model: task-scoped
-overall_progress: 75
-completion_estimate: on-track
+overall_progress: 100
+completion_estimate: complete
 total_tasks: 4
-completed_tasks: 3
+completed_tasks: 4
 in_progress_tasks: 0
 blocked_tasks: 0
 at_risk_tasks: 0
@@ -61,7 +61,7 @@ tasks:
   priority: high
 - id: ING-004
   description: Confirm publish counts reflect real changed sessions, not alias re-ingestion.
-  status: pending
+  status: completed
   assigned_to:
   - python-backend-engineer
   - data-layer-expert
@@ -92,7 +92,7 @@ files_modified:
 - backend/tests/test_file_watcher.py
 - backend/tests/test_sync_engine_linking.py
 - .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-2-progress.md
-progress: 75
+progress: 100
 ---
 
 # live-ingest-source-path-canonicalization-hardening-v1 - Phase 2
@@ -103,4 +103,4 @@ Apply canonical source keys at ingest lookup/write/delete boundaries after the P
 
 ## Current Status
 
-`ING-001`, `ING-002`, and `ING-003` are complete. Alias-path session reingest now keeps replace-scoped tables stable with canonical source identity keys.
+Phase 2 is complete. Alias-path unchanged sessions skip parsing and live fanout when canonical sync state and lineage are already current.

--- a/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-2-progress.md
+++ b/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-2-progress.md
@@ -1,0 +1,103 @@
+---
+type: progress
+schema_version: 2
+doc_type: progress
+feature_slug: live-ingest-source-path-canonicalization-hardening
+phase: 2
+phase_title: Ingest Path Canonicalization
+title: 'live-ingest-source-path-canonicalization-hardening-v1 - Phase 2: Ingest Path Canonicalization'
+status: pending
+started: null
+completed: null
+created: '2026-05-04'
+updated: '2026-05-04'
+prd_ref: null
+plan_ref: docs/project_plans/implementation_plans/infrastructure/live-ingest-source-path-canonicalization-hardening-v1.md
+commit_refs: []
+pr_refs: []
+execution_model: task-scoped
+overall_progress: 0
+completion_estimate: not-started
+total_tasks: 4
+completed_tasks: 0
+in_progress_tasks: 0
+blocked_tasks: 0
+at_risk_tasks: 0
+owners:
+- python-backend-engineer
+- data-layer-expert
+contributors: []
+tasks:
+- id: ING-001
+  description: Update sync state lookup, upsert, and delete usage sites so startup sync checks canonical source identity before deciding a file is new.
+  status: pending
+  assigned_to:
+  - python-backend-engineer
+  - data-layer-expert
+  dependencies:
+  - SRC-002
+  estimated_effort: 2 pts
+  priority: high
+- id: ING-002
+  description: Normalize sessions.source_file at write boundaries or add an explicit canonical source column while preserving display/debug compatibility.
+  status: pending
+  assigned_to:
+  - python-backend-engineer
+  - data-layer-expert
+  dependencies:
+  - SRC-002
+  estimated_effort: 2 pts
+  priority: high
+- id: ING-003
+  description: Ensure delete/replace boundaries do not duplicate rows when the same physical file appears through an alias path.
+  status: pending
+  assigned_to:
+  - python-backend-engineer
+  - data-layer-expert
+  dependencies:
+  - ING-001
+  - ING-002
+  estimated_effort: 2 pts
+  priority: high
+- id: ING-004
+  description: Confirm publish counts reflect real changed sessions, not alias re-ingestion.
+  status: pending
+  assigned_to:
+  - python-backend-engineer
+  - data-layer-expert
+  dependencies:
+  - ING-003
+  estimated_effort: 1 pt
+  priority: high
+parallelization:
+  batch_1:
+  - ING-001
+  - ING-002
+  batch_2:
+  - ING-003
+  batch_3:
+  - ING-004
+  critical_path:
+  - SRC-002
+  - ING-001
+  - ING-003
+  - ING-004
+blockers:
+- Phase 2 depends on SRC-002 helper implementation, which is intentionally pending after SRC-001.
+success_criteria:
+- A second startup under container paths skips files already synced under host paths when content/mtime is unchanged.
+- Existing local SQLite tests still pass.
+- Existing Postgres repository tests still pass.
+files_modified: []
+progress: 0
+---
+
+# live-ingest-source-path-canonicalization-hardening-v1 - Phase 2
+
+## Objective
+
+Apply canonical source keys at ingest lookup/write/delete boundaries after the Phase 1 helper contract is implemented.
+
+## Current Status
+
+Phase 2 has not started.

--- a/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-3-progress.md
+++ b/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-3-progress.md
@@ -16,10 +16,10 @@ plan_ref: docs/project_plans/implementation_plans/infrastructure/live-ingest-sou
 commit_refs: []
 pr_refs: []
 execution_model: task-scoped
-overall_progress: 50
-completion_estimate: 2 tasks remaining
+overall_progress: 75
+completion_estimate: 1 task remaining
 total_tasks: 4
-completed_tasks: 2
+completed_tasks: 3
 in_progress_tasks: 0
 blocked_tasks: 0
 at_risk_tasks: 0
@@ -49,7 +49,7 @@ tasks:
   priority: high
 - id: MIG-003
   description: Implement a project-scoped dry-run/apply command for duplicate source identity collapse.
-  status: pending
+  status: completed
   assigned_to:
   - python-backend-engineer
   dependencies:
@@ -88,7 +88,7 @@ files_modified:
 - backend/scripts/source_alias_duplicate_audit.py
 - backend/tests/test_source_alias_duplicate_audit.py
 - .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-3-progress.md
-progress: 50
+progress: 75
 ---
 
 # live-ingest-source-path-canonicalization-hardening-v1 - Phase 3
@@ -99,4 +99,4 @@ Add project-scoped duplicate source identity audit and collapse tooling for host
 
 ## Current Status
 
-Phase 3 is in progress. MIG-001 added the audit script; MIG-002 added survivor selection and dry-run collapse strategy coverage.
+Phase 3 is in progress. MIG-001 added the audit script, MIG-002 added survivor selection, and MIG-003 added dry-run/apply collapse commands.

--- a/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-3-progress.md
+++ b/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-3-progress.md
@@ -6,7 +6,7 @@ feature_slug: live-ingest-source-path-canonicalization-hardening
 phase: 3
 phase_title: Duplicate Migration And Backfill
 title: 'live-ingest-source-path-canonicalization-hardening-v1 - Phase 3: Duplicate Migration And Backfill'
-status: in-progress
+status: completed
 started: '2026-05-04'
 completed: null
 created: '2026-05-04'
@@ -16,10 +16,10 @@ plan_ref: docs/project_plans/implementation_plans/infrastructure/live-ingest-sou
 commit_refs: []
 pr_refs: []
 execution_model: task-scoped
-overall_progress: 75
-completion_estimate: 1 task remaining
+overall_progress: 100
+completion_estimate: complete
 total_tasks: 4
-completed_tasks: 3
+completed_tasks: 4
 in_progress_tasks: 0
 blocked_tasks: 0
 at_risk_tasks: 0
@@ -58,7 +58,7 @@ tasks:
   priority: high
 - id: MIG-004
   description: Verify table counts, live feature/session views, and source lookup behavior after cleanup.
-  status: pending
+  status: completed
   assigned_to:
   - task-completion-validator
   dependencies:
@@ -88,7 +88,7 @@ files_modified:
 - backend/scripts/source_alias_duplicate_audit.py
 - backend/tests/test_source_alias_duplicate_audit.py
 - .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-3-progress.md
-progress: 75
+progress: 100
 ---
 
 # live-ingest-source-path-canonicalization-hardening-v1 - Phase 3
@@ -99,4 +99,12 @@ Add project-scoped duplicate source identity audit and collapse tooling for host
 
 ## Current Status
 
-Phase 3 is in progress. MIG-001 added the audit script, MIG-002 added survivor selection, and MIG-003 added dry-run/apply collapse commands.
+Phase 3 is complete. The live dry-run audit for `default-skillmeat` reported zero duplicate source alias groups, so no apply cleanup was run.
+
+## Validation Evidence
+
+- `python -m pytest backend/tests/test_source_alias_duplicate_audit.py backend/tests/test_source_identity.py backend/tests/test_sync_engine_linking.py backend/tests/test_file_watcher.py -q` -> 42 passed.
+- `python backend/scripts/source_alias_duplicate_audit.py --project default-skillmeat --strategy` -> printed the project-scoped dry-run/rollback strategy.
+- `python backend/scripts/source_alias_duplicate_audit.py --project default-skillmeat --database-url postgresql://ccdash:ccdash@127.0.0.1:5433/ccdash --env-file deploy/runtime/.env --collapse-plan --json` -> `plannedGroups=0`, `applied=false`.
+- `python backend/scripts/source_alias_duplicate_audit.py --project default-skillmeat --database-url postgresql://ccdash:ccdash@127.0.0.1:5433/ccdash --env-file deploy/runtime/.env --json` -> `duplicateGroupCount=0`.
+- `docker-compose --env-file deploy/runtime/.env -f deploy/runtime/compose.yaml --profile enterprise --profile postgres --profile live-watch exec -T postgres psql -U ccdash -d ccdash -c "select relname, n_live_tup, n_dead_tup, n_tup_ins, n_tup_del from pg_stat_user_tables where relname in ('sessions','session_messages','telemetry_events','session_usage_attributions','sync_state') order by relname;"` captured live table stats for the validation baseline.

--- a/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-3-progress.md
+++ b/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-3-progress.md
@@ -10,10 +10,14 @@ status: completed
 started: '2026-05-04'
 completed: null
 created: '2026-05-04'
-updated: '2026-05-04'
+updated: '2026-05-05'
 prd_ref: null
 plan_ref: docs/project_plans/implementation_plans/infrastructure/live-ingest-source-path-canonicalization-hardening-v1.md
-commit_refs: []
+commit_refs:
+- 148b098
+- 200eb00
+- 07d8d73
+- 015e0a8
 pr_refs: []
 execution_model: task-scoped
 overall_progress: 100

--- a/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-3-progress.md
+++ b/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-3-progress.md
@@ -1,0 +1,99 @@
+---
+type: progress
+schema_version: 2
+doc_type: progress
+feature_slug: live-ingest-source-path-canonicalization-hardening
+phase: 3
+phase_title: Duplicate Migration And Backfill
+title: 'live-ingest-source-path-canonicalization-hardening-v1 - Phase 3: Duplicate Migration And Backfill'
+status: in-progress
+started: '2026-05-04'
+completed: null
+created: '2026-05-04'
+updated: '2026-05-04'
+prd_ref: null
+plan_ref: docs/project_plans/implementation_plans/infrastructure/live-ingest-source-path-canonicalization-hardening-v1.md
+commit_refs: []
+pr_refs: []
+execution_model: task-scoped
+overall_progress: 0
+completion_estimate: pending
+total_tasks: 4
+completed_tasks: 0
+in_progress_tasks: 0
+blocked_tasks: 0
+at_risk_tasks: 0
+owners:
+- data-layer-expert
+- python-backend-engineer
+contributors: []
+tasks:
+- id: MIG-001
+  description: Add repeatable SQL or a CLI/admin script that reports host/container alias duplicates in sync_state, sessions, and derived tables.
+  status: pending
+  assigned_to:
+  - data-layer-expert
+  dependencies:
+  - SRC-002
+  estimated_effort: 1 pt
+  priority: high
+- id: MIG-002
+  description: Define how to choose survivor rows and update or delete duplicate rows without losing newer mtime/hash data or canonical transcript rows.
+  status: pending
+  assigned_to:
+  - data-layer-expert
+  - python-backend-engineer
+  dependencies:
+  - MIG-001
+  estimated_effort: 1 pt
+  priority: high
+- id: MIG-003
+  description: Implement a project-scoped dry-run/apply command for duplicate source identity collapse.
+  status: pending
+  assigned_to:
+  - python-backend-engineer
+  dependencies:
+  - MIG-002
+  estimated_effort: 2 pts
+  priority: high
+- id: MIG-004
+  description: Verify table counts, live feature/session views, and source lookup behavior after cleanup.
+  status: pending
+  assigned_to:
+  - task-completion-validator
+  dependencies:
+  - MIG-003
+  estimated_effort: 1 pt
+  priority: high
+parallelization:
+  batch_1:
+  - MIG-001
+  batch_2:
+  - MIG-002
+  batch_3:
+  - MIG-003
+  batch_4:
+  - MIG-004
+  critical_path:
+  - MIG-001
+  - MIG-002
+  - MIG-003
+  - MIG-004
+blockers: []
+success_criteria:
+- The audit script reports duplicate alias counts and exits non-zero only on query failure.
+- Migration requires an explicit project id and supports dry-run review before apply.
+- Duplicate cleanup is restart-safe, idempotent, and preserves newer sync/session evidence.
+files_modified: []
+progress: 0
+---
+
+# live-ingest-source-path-canonicalization-hardening-v1 - Phase 3
+
+## Objective
+
+Add project-scoped duplicate source identity audit and collapse tooling for host/container alias drift.
+
+## Current Status
+
+Phase 3 is in progress. Phases 1 and 2 completed the canonical identity helper and ingest write-boundary usage.

--- a/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-3-progress.md
+++ b/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-3-progress.md
@@ -16,10 +16,10 @@ plan_ref: docs/project_plans/implementation_plans/infrastructure/live-ingest-sou
 commit_refs: []
 pr_refs: []
 execution_model: task-scoped
-overall_progress: 25
-completion_estimate: 3 tasks remaining
+overall_progress: 50
+completion_estimate: 2 tasks remaining
 total_tasks: 4
-completed_tasks: 1
+completed_tasks: 2
 in_progress_tasks: 0
 blocked_tasks: 0
 at_risk_tasks: 0
@@ -39,7 +39,7 @@ tasks:
   priority: high
 - id: MIG-002
   description: Define how to choose survivor rows and update or delete duplicate rows without losing newer mtime/hash data or canonical transcript rows.
-  status: pending
+  status: completed
   assigned_to:
   - data-layer-expert
   - python-backend-engineer
@@ -88,7 +88,7 @@ files_modified:
 - backend/scripts/source_alias_duplicate_audit.py
 - backend/tests/test_source_alias_duplicate_audit.py
 - .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-3-progress.md
-progress: 25
+progress: 50
 ---
 
 # live-ingest-source-path-canonicalization-hardening-v1 - Phase 3
@@ -99,4 +99,4 @@ Add project-scoped duplicate source identity audit and collapse tooling for host
 
 ## Current Status
 
-Phase 3 is in progress. MIG-001 added the project-scoped source alias duplicate audit script and unit coverage.
+Phase 3 is in progress. MIG-001 added the audit script; MIG-002 added survivor selection and dry-run collapse strategy coverage.

--- a/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-3-progress.md
+++ b/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-3-progress.md
@@ -16,10 +16,10 @@ plan_ref: docs/project_plans/implementation_plans/infrastructure/live-ingest-sou
 commit_refs: []
 pr_refs: []
 execution_model: task-scoped
-overall_progress: 0
-completion_estimate: pending
+overall_progress: 25
+completion_estimate: 3 tasks remaining
 total_tasks: 4
-completed_tasks: 0
+completed_tasks: 1
 in_progress_tasks: 0
 blocked_tasks: 0
 at_risk_tasks: 0
@@ -30,7 +30,7 @@ contributors: []
 tasks:
 - id: MIG-001
   description: Add repeatable SQL or a CLI/admin script that reports host/container alias duplicates in sync_state, sessions, and derived tables.
-  status: pending
+  status: completed
   assigned_to:
   - data-layer-expert
   dependencies:
@@ -84,8 +84,11 @@ success_criteria:
 - The audit script reports duplicate alias counts and exits non-zero only on query failure.
 - Migration requires an explicit project id and supports dry-run review before apply.
 - Duplicate cleanup is restart-safe, idempotent, and preserves newer sync/session evidence.
-files_modified: []
-progress: 0
+files_modified:
+- backend/scripts/source_alias_duplicate_audit.py
+- backend/tests/test_source_alias_duplicate_audit.py
+- .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-3-progress.md
+progress: 25
 ---
 
 # live-ingest-source-path-canonicalization-hardening-v1 - Phase 3
@@ -96,4 +99,4 @@ Add project-scoped duplicate source identity audit and collapse tooling for host
 
 ## Current Status
 
-Phase 3 is in progress. Phases 1 and 2 completed the canonical identity helper and ingest write-boundary usage.
+Phase 3 is in progress. MIG-001 added the project-scoped source alias duplicate audit script and unit coverage.

--- a/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-4-progress.md
+++ b/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-4-progress.md
@@ -8,12 +8,15 @@ phase_title: Runtime Guardrails And Operator Docs
 title: 'live-ingest-source-path-canonicalization-hardening-v1 - Phase 4: Runtime Guardrails And Operator Docs'
 status: completed
 started: '2026-05-04'
-completed: null
+completed: '2026-05-04'
 created: '2026-05-04'
-updated: '2026-05-04'
+updated: '2026-05-05'
 prd_ref: null
 plan_ref: docs/project_plans/implementation_plans/infrastructure/live-ingest-source-path-canonicalization-hardening-v1.md
-commit_refs: []
+commit_refs:
+- b637d43
+- a311f79
+- e6a6baf
 pr_refs: []
 execution_model: task-scoped
 overall_progress: 100

--- a/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-4-progress.md
+++ b/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-4-progress.md
@@ -1,0 +1,83 @@
+---
+type: progress
+schema_version: 2
+doc_type: progress
+feature_slug: live-ingest-source-path-canonicalization-hardening
+phase: 4
+phase_title: Runtime Guardrails And Operator Docs
+title: 'live-ingest-source-path-canonicalization-hardening-v1 - Phase 4: Runtime Guardrails And Operator Docs'
+status: in-progress
+started: '2026-05-04'
+completed: null
+created: '2026-05-04'
+updated: '2026-05-04'
+prd_ref: null
+plan_ref: docs/project_plans/implementation_plans/infrastructure/live-ingest-source-path-canonicalization-hardening-v1.md
+commit_refs: []
+pr_refs: []
+execution_model: task-scoped
+overall_progress: 0
+completion_estimate: pending
+total_tasks: 3
+completed_tasks: 0
+in_progress_tasks: 0
+blocked_tasks: 0
+at_risk_tasks: 0
+owners:
+- DevOps
+- documentation-writer
+contributors: []
+tasks:
+- id: OPS-001
+  description: Document startup sync load versus idle polling load and explain WATCHFILES_FORCE_POLLING as a worker-watch compatibility fallback.
+  status: in-progress
+  assigned_to:
+  - DevOps
+  - documentation-writer
+  dependencies: []
+  estimated_effort: 1 pt
+  priority: medium
+- id: OPS-002
+  description: Document host port 8000 conflict checks and safer stack validation through frontend proxy or container probes.
+  status: pending
+  assigned_to:
+  - documentation-writer
+  dependencies: []
+  estimated_effort: 1 pt
+  priority: medium
+- id: OPS-003
+  description: Document how sessionsPath, .claude, .codex, workspace roots, and optional mounts affect watch size and startup cost.
+  status: pending
+  assigned_to:
+  - documentation-writer
+  dependencies:
+  - SRC-001
+  estimated_effort: 1 pt
+  priority: medium
+parallelization:
+  batch_1:
+  - OPS-001
+  - OPS-002
+  batch_2:
+  - OPS-003
+  critical_path:
+  - OPS-001
+  - OPS-003
+blockers: []
+success_criteria:
+- Runtime docs use docker-compose for this environment and do not assume standalone docker.
+- Docs include expected CPU/RAM interpretation rather than only commands.
+- Docs do not present polling mode as a default performance setting.
+files_modified: []
+progress: 0
+---
+
+# live-ingest-source-path-canonicalization-hardening-v1 - Phase 4
+
+## Objective
+
+Add runtime operator guardrails for live-watch startup, polling fallback, port validation, and watch scope sizing.
+
+## Current Status
+
+Phase 4 is in progress. OPS-001 has been delegated; OPS-002 and OPS-003 remain pending.

--- a/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-4-progress.md
+++ b/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-4-progress.md
@@ -6,7 +6,7 @@ feature_slug: live-ingest-source-path-canonicalization-hardening
 phase: 4
 phase_title: Runtime Guardrails And Operator Docs
 title: 'live-ingest-source-path-canonicalization-hardening-v1 - Phase 4: Runtime Guardrails And Operator Docs'
-status: in-progress
+status: completed
 started: '2026-05-04'
 completed: null
 created: '2026-05-04'
@@ -16,10 +16,10 @@ plan_ref: docs/project_plans/implementation_plans/infrastructure/live-ingest-sou
 commit_refs: []
 pr_refs: []
 execution_model: task-scoped
-overall_progress: 67
-completion_estimate: 1 task remaining
+overall_progress: 100
+completion_estimate: complete
 total_tasks: 3
-completed_tasks: 2
+completed_tasks: 3
 in_progress_tasks: 0
 blocked_tasks: 0
 at_risk_tasks: 0
@@ -47,7 +47,7 @@ tasks:
   priority: medium
 - id: OPS-003
   description: Document how sessionsPath, .claude, .codex, workspace roots, and optional mounts affect watch size and startup cost.
-  status: pending
+  status: completed
   assigned_to:
   - documentation-writer
   dependencies:
@@ -71,7 +71,7 @@ success_criteria:
 files_modified:
 - deploy/runtime/README.md
 - .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-4-progress.md
-progress: 67
+progress: 100
 ---
 
 # live-ingest-source-path-canonicalization-hardening-v1 - Phase 4
@@ -82,4 +82,4 @@ Add runtime operator guardrails for live-watch startup, polling fallback, port v
 
 ## Current Status
 
-Phase 4 is in progress. OPS-001 and OPS-002 are complete; OPS-003 remains pending.
+Phase 4 is complete. Runtime docs now cover polling load, port conflict checks, and watch scope startup cost.

--- a/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-4-progress.md
+++ b/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-4-progress.md
@@ -16,10 +16,10 @@ plan_ref: docs/project_plans/implementation_plans/infrastructure/live-ingest-sou
 commit_refs: []
 pr_refs: []
 execution_model: task-scoped
-overall_progress: 33
-completion_estimate: 2 tasks remaining
+overall_progress: 67
+completion_estimate: 1 task remaining
 total_tasks: 3
-completed_tasks: 1
+completed_tasks: 2
 in_progress_tasks: 0
 blocked_tasks: 0
 at_risk_tasks: 0
@@ -39,7 +39,7 @@ tasks:
   priority: medium
 - id: OPS-002
   description: Document host port 8000 conflict checks and safer stack validation through frontend proxy or container probes.
-  status: pending
+  status: completed
   assigned_to:
   - documentation-writer
   dependencies: []
@@ -71,7 +71,7 @@ success_criteria:
 files_modified:
 - deploy/runtime/README.md
 - .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-4-progress.md
-progress: 33
+progress: 67
 ---
 
 # live-ingest-source-path-canonicalization-hardening-v1 - Phase 4
@@ -82,4 +82,4 @@ Add runtime operator guardrails for live-watch startup, polling fallback, port v
 
 ## Current Status
 
-Phase 4 is in progress. OPS-001 is complete; OPS-002 and OPS-003 remain pending.
+Phase 4 is in progress. OPS-001 and OPS-002 are complete; OPS-003 remains pending.

--- a/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-4-progress.md
+++ b/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-4-progress.md
@@ -16,10 +16,10 @@ plan_ref: docs/project_plans/implementation_plans/infrastructure/live-ingest-sou
 commit_refs: []
 pr_refs: []
 execution_model: task-scoped
-overall_progress: 0
-completion_estimate: pending
+overall_progress: 33
+completion_estimate: 2 tasks remaining
 total_tasks: 3
-completed_tasks: 0
+completed_tasks: 1
 in_progress_tasks: 0
 blocked_tasks: 0
 at_risk_tasks: 0
@@ -30,7 +30,7 @@ contributors: []
 tasks:
 - id: OPS-001
   description: Document startup sync load versus idle polling load and explain WATCHFILES_FORCE_POLLING as a worker-watch compatibility fallback.
-  status: in-progress
+  status: completed
   assigned_to:
   - DevOps
   - documentation-writer
@@ -68,8 +68,10 @@ success_criteria:
 - Runtime docs use docker-compose for this environment and do not assume standalone docker.
 - Docs include expected CPU/RAM interpretation rather than only commands.
 - Docs do not present polling mode as a default performance setting.
-files_modified: []
-progress: 0
+files_modified:
+- deploy/runtime/README.md
+- .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-4-progress.md
+progress: 33
 ---
 
 # live-ingest-source-path-canonicalization-hardening-v1 - Phase 4
@@ -80,4 +82,4 @@ Add runtime operator guardrails for live-watch startup, polling fallback, port v
 
 ## Current Status
 
-Phase 4 is in progress. OPS-001 has been delegated; OPS-002 and OPS-003 remain pending.
+Phase 4 is in progress. OPS-001 is complete; OPS-002 and OPS-003 remain pending.

--- a/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-5-progress.md
+++ b/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-5-progress.md
@@ -16,10 +16,10 @@ plan_ref: docs/project_plans/implementation_plans/infrastructure/live-ingest-sou
 commit_refs: []
 pr_refs: []
 execution_model: task-scoped
-overall_progress: 25
-completion_estimate: 3 tasks remaining
+overall_progress: 50
+completion_estimate: 2 tasks remaining
 total_tasks: 4
-completed_tasks: 1
+completed_tasks: 2
 in_progress_tasks: 0
 blocked_tasks: 0
 at_risk_tasks: 0
@@ -40,7 +40,7 @@ tasks:
   priority: high
 - id: VAL-002
   description: Sample worker-watch CPU and memory every 30 seconds for 10 minutes after startup completes with no file changes.
-  status: pending
+  status: completed
   assigned_to:
   - performance-engineer
   dependencies:
@@ -83,7 +83,7 @@ success_criteria:
 - Focused regression tests pass or caveats are recorded with exact command output.
 files_modified:
 - .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-5-progress.md
-progress: 25
+progress: 50
 ---
 
 # live-ingest-source-path-canonicalization-hardening-v1 - Phase 5
@@ -104,3 +104,12 @@ Phase 5 is in progress. VAL-001 completed live startup idempotence smoke against
 - `docker-compose ... restart worker-watch` triggered a second startup sync.
 - Second startup sync completed at `2026-05-05T03:07:32Z`: `startupSync=succeeded`, backlog `0`, readiness `pass`, `lastDurationMs=112252`, `published=11`, `publishErrors=0`.
 - The second startup did not bulk re-publish the corpus and completed materially faster than the first startup.
+
+## VAL-002 Evidence
+
+- `for i in $(seq 1 20); do date -u +sample=%Y-%m-%dT%H:%M:%SZ; docker-compose --env-file deploy/runtime/.env -f deploy/runtime/compose.yaml --profile enterprise --profile postgres --profile live-watch stats --no-stream | awk 'NR==1 || /ccdash-worker-watch-1|ccdash-postgres-1/'; sleep 30; done`
+- Window: `2026-05-05T03:08:09Z` through `2026-05-05T03:18:30Z`, 20 samples.
+- `WATCHFILES_FORCE_POLLING=true` in `deploy/runtime/.env`.
+- `worker-watch` CPU stayed sustained but bounded in the polling range, roughly `12.01%` to `22.30%`.
+- `worker-watch` RSS rose from about `164 MiB` to about `267 MiB` early in the idle window, then remained flat near `266-269 MiB`; no monotonic growth across the full window.
+- Postgres CPU was mostly `0.00-0.10%` after startup, with brief samples at `2.64-2.78%`; Postgres RSS dropped from about `353 MiB` to about `300 MiB`.

--- a/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-5-progress.md
+++ b/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-5-progress.md
@@ -16,10 +16,10 @@ plan_ref: docs/project_plans/implementation_plans/infrastructure/live-ingest-sou
 commit_refs: []
 pr_refs: []
 execution_model: task-scoped
-overall_progress: 50
-completion_estimate: 2 tasks remaining
+overall_progress: 75
+completion_estimate: 1 task remaining
 total_tasks: 4
-completed_tasks: 2
+completed_tasks: 3
 in_progress_tasks: 0
 blocked_tasks: 0
 at_risk_tasks: 0
@@ -49,7 +49,7 @@ tasks:
   priority: medium
 - id: VAL-003
   description: Capture table stats before and after second startup to ensure unchanged rows and dead tuples do not grow materially.
-  status: pending
+  status: completed
   assigned_to:
   - performance-engineer
   dependencies:
@@ -83,7 +83,7 @@ success_criteria:
 - Focused regression tests pass or caveats are recorded with exact command output.
 files_modified:
 - .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-5-progress.md
-progress: 50
+progress: 75
 ---
 
 # live-ingest-source-path-canonicalization-hardening-v1 - Phase 5
@@ -113,3 +113,15 @@ Phase 5 is in progress. VAL-001 completed live startup idempotence smoke against
 - `worker-watch` CPU stayed sustained but bounded in the polling range, roughly `12.01%` to `22.30%`.
 - `worker-watch` RSS rose from about `164 MiB` to about `267 MiB` early in the idle window, then remained flat near `266-269 MiB`; no monotonic growth across the full window.
 - Postgres CPU was mostly `0.00-0.10%` after startup, with brief samples at `2.64-2.78%`; Postgres RSS dropped from about `353 MiB` to about `300 MiB`.
+
+## VAL-003 Evidence
+
+- Before second restart table stats:
+  - `session_messages n_tup_ins=926289 n_tup_del=495089`
+  - `session_usage_attributions n_tup_ins=3058160 n_tup_del=1484582`
+  - `sessions n_tup_ins=9003 n_tup_del=2072`
+  - `sync_state n_tup_ins=14382 n_tup_del=37`
+  - `telemetry_events n_tup_ins=1488890 n_tup_del=794202`
+- Immediately after second startup, the same table counters were unchanged.
+- After the 10-minute idle window, the same table counters were still unchanged.
+- `worker-watch /detailz` remained `ready=pass`, `startupSync=succeeded`, backlog `0`, publisher `published=11`, `publishErrors=0`.

--- a/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-5-progress.md
+++ b/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-5-progress.md
@@ -1,0 +1,96 @@
+---
+type: progress
+schema_version: 2
+doc_type: progress
+feature_slug: live-ingest-source-path-canonicalization-hardening
+phase: 5
+phase_title: Performance Validation Gate
+title: 'live-ingest-source-path-canonicalization-hardening-v1 - Phase 5: Performance Validation Gate'
+status: pending
+started: null
+completed: null
+created: '2026-05-04'
+updated: '2026-05-04'
+prd_ref: null
+plan_ref: docs/project_plans/implementation_plans/infrastructure/live-ingest-source-path-canonicalization-hardening-v1.md
+commit_refs: []
+pr_refs: []
+execution_model: task-scoped
+overall_progress: 0
+completion_estimate: pending
+total_tasks: 4
+completed_tasks: 0
+in_progress_tasks: 0
+blocked_tasks: 0
+at_risk_tasks: 0
+owners:
+- performance-engineer
+- task-completion-validator
+contributors: []
+tasks:
+- id: VAL-001
+  description: Start the stack twice and compare sync, fanout, and write counts for unchanged alias-path files.
+  status: pending
+  assigned_to:
+  - performance-engineer
+  dependencies:
+  - ING-004
+  - MIG-004
+  estimated_effort: 2 pts
+  priority: high
+- id: VAL-002
+  description: Sample worker-watch CPU and memory every 30 seconds for 10 minutes after startup completes with no file changes.
+  status: pending
+  assigned_to:
+  - performance-engineer
+  dependencies:
+  - VAL-001
+  estimated_effort: 1 pt
+  priority: medium
+- id: VAL-003
+  description: Capture table stats before and after second startup to ensure unchanged rows and dead tuples do not grow materially.
+  status: pending
+  assigned_to:
+  - performance-engineer
+  dependencies:
+  - VAL-001
+  estimated_effort: 1 pt
+  priority: high
+- id: VAL-004
+  description: Run focused backend tests for watcher, runtime bootstrap, fanout, sync writes, canonicalization, and migration coverage.
+  status: pending
+  assigned_to:
+  - task-completion-validator
+  dependencies:
+  - ING-004
+  - MIG-004
+  estimated_effort: 1 pt
+  priority: high
+parallelization:
+  batch_1:
+  - VAL-001
+  batch_2:
+  - VAL-002
+  - VAL-003
+  - VAL-004
+  critical_path:
+  - VAL-001
+  - VAL-003
+blockers: []
+success_criteria:
+- Second startup does not bulk re-ingest unchanged alias-path session files.
+- Idle CPU/RAM evidence distinguishes startup load from sustained idle behavior.
+- Focused regression tests pass or caveats are recorded with exact command output.
+files_modified: []
+progress: 0
+---
+
+# live-ingest-source-path-canonicalization-hardening-v1 - Phase 5
+
+## Objective
+
+Validate startup idempotence, idle resource behavior, Postgres churn, and regression coverage after phases 3 and 4 complete.
+
+## Current Status
+
+Phase 5 is pending until the migration/backfill tooling and operator guardrails are complete.

--- a/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-5-progress.md
+++ b/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-5-progress.md
@@ -10,10 +10,14 @@ status: completed
 started: '2026-05-05'
 completed: '2026-05-05'
 created: '2026-05-04'
-updated: '2026-05-04'
+updated: '2026-05-05'
 prd_ref: null
 plan_ref: docs/project_plans/implementation_plans/infrastructure/live-ingest-source-path-canonicalization-hardening-v1.md
-commit_refs: []
+commit_refs:
+- d609db2
+- ebc2a45
+- b64024b
+- 36effc0
 pr_refs: []
 execution_model: task-scoped
 overall_progress: 100
@@ -94,7 +98,7 @@ Validate startup idempotence, idle resource behavior, Postgres churn, and regres
 
 ## Current Status
 
-Phase 5 is in progress. VAL-001 completed live startup idempotence smoke against the compose enterprise/postgres/live-watch stack.
+Phase 5 is complete. Live startup/idempotence, idle resource, Postgres churn, and focused regression validation evidence has been recorded.
 
 ## VAL-001 Evidence
 

--- a/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-5-progress.md
+++ b/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-5-progress.md
@@ -6,8 +6,8 @@ feature_slug: live-ingest-source-path-canonicalization-hardening
 phase: 5
 phase_title: Performance Validation Gate
 title: 'live-ingest-source-path-canonicalization-hardening-v1 - Phase 5: Performance Validation Gate'
-status: pending
-started: null
+status: in-progress
+started: '2026-05-05'
 completed: null
 created: '2026-05-04'
 updated: '2026-05-04'
@@ -16,10 +16,10 @@ plan_ref: docs/project_plans/implementation_plans/infrastructure/live-ingest-sou
 commit_refs: []
 pr_refs: []
 execution_model: task-scoped
-overall_progress: 0
-completion_estimate: pending
+overall_progress: 25
+completion_estimate: 3 tasks remaining
 total_tasks: 4
-completed_tasks: 0
+completed_tasks: 1
 in_progress_tasks: 0
 blocked_tasks: 0
 at_risk_tasks: 0
@@ -30,7 +30,7 @@ contributors: []
 tasks:
 - id: VAL-001
   description: Start the stack twice and compare sync, fanout, and write counts for unchanged alias-path files.
-  status: pending
+  status: completed
   assigned_to:
   - performance-engineer
   dependencies:
@@ -81,8 +81,9 @@ success_criteria:
 - Second startup does not bulk re-ingest unchanged alias-path session files.
 - Idle CPU/RAM evidence distinguishes startup load from sustained idle behavior.
 - Focused regression tests pass or caveats are recorded with exact command output.
-files_modified: []
-progress: 0
+files_modified:
+- .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-5-progress.md
+progress: 25
 ---
 
 # live-ingest-source-path-canonicalization-hardening-v1 - Phase 5
@@ -93,4 +94,13 @@ Validate startup idempotence, idle resource behavior, Postgres churn, and regres
 
 ## Current Status
 
-Phase 5 is pending until the migration/backfill tooling and operator guardrails are complete.
+Phase 5 is in progress. VAL-001 completed live startup idempotence smoke against the compose enterprise/postgres/live-watch stack.
+
+## VAL-001 Evidence
+
+- `docker-compose --env-file deploy/runtime/.env -f deploy/runtime/compose.yaml --profile enterprise --profile postgres --profile live-watch up -d` started the stack.
+- First `worker-watch` startup sync completed at `2026-05-05T03:05:14Z`: `startupSync=succeeded`, backlog `0`, readiness `pass`, `lastDurationMs=576388`.
+- Before restart, live fanout publisher reported `published=1424`, `publishErrors=0`.
+- `docker-compose ... restart worker-watch` triggered a second startup sync.
+- Second startup sync completed at `2026-05-05T03:07:32Z`: `startupSync=succeeded`, backlog `0`, readiness `pass`, `lastDurationMs=112252`, `published=11`, `publishErrors=0`.
+- The second startup did not bulk re-publish the corpus and completed materially faster than the first startup.

--- a/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-5-progress.md
+++ b/.claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-5-progress.md
@@ -6,9 +6,9 @@ feature_slug: live-ingest-source-path-canonicalization-hardening
 phase: 5
 phase_title: Performance Validation Gate
 title: 'live-ingest-source-path-canonicalization-hardening-v1 - Phase 5: Performance Validation Gate'
-status: in-progress
+status: completed
 started: '2026-05-05'
-completed: null
+completed: '2026-05-05'
 created: '2026-05-04'
 updated: '2026-05-04'
 prd_ref: null
@@ -16,10 +16,10 @@ plan_ref: docs/project_plans/implementation_plans/infrastructure/live-ingest-sou
 commit_refs: []
 pr_refs: []
 execution_model: task-scoped
-overall_progress: 75
-completion_estimate: 1 task remaining
+overall_progress: 100
+completion_estimate: complete
 total_tasks: 4
-completed_tasks: 3
+completed_tasks: 4
 in_progress_tasks: 0
 blocked_tasks: 0
 at_risk_tasks: 0
@@ -58,7 +58,7 @@ tasks:
   priority: high
 - id: VAL-004
   description: Run focused backend tests for watcher, runtime bootstrap, fanout, sync writes, canonicalization, and migration coverage.
-  status: pending
+  status: completed
   assigned_to:
   - task-completion-validator
   dependencies:
@@ -83,7 +83,7 @@ success_criteria:
 - Focused regression tests pass or caveats are recorded with exact command output.
 files_modified:
 - .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-5-progress.md
-progress: 75
+progress: 100
 ---
 
 # live-ingest-source-path-canonicalization-hardening-v1 - Phase 5
@@ -125,3 +125,17 @@ Phase 5 is in progress. VAL-001 completed live startup idempotence smoke against
 - Immediately after second startup, the same table counters were unchanged.
 - After the 10-minute idle window, the same table counters were still unchanged.
 - `worker-watch /detailz` remained `ready=pass`, `startupSync=succeeded`, backlog `0`, publisher `published=11`, `publishErrors=0`.
+
+## VAL-004 Evidence
+
+- Combined command attempted: `python -m pytest backend/tests/test_file_watcher.py backend/tests/test_runtime_bootstrap.py backend/tests/test_postgres_live_fanout.py backend/tests/test_sync_engine_linking.py backend/tests/test_sync_engine_transcript_live_updates.py backend/tests/test_source_identity.py backend/tests/test_source_alias_duplicate_audit.py -q`.
+- Combined command failed before test execution with a Python 3.12 segmentation fault during import/collection.
+- Split focused passes:
+  - `python -m pytest backend/tests/test_file_watcher.py backend/tests/test_source_identity.py backend/tests/test_source_alias_duplicate_audit.py backend/tests/test_sync_engine_linking.py -q` -> 42 passed.
+  - `python -m pytest backend/tests/test_postgres_live_fanout.py -q` -> 11 passed.
+  - `python -m pytest backend/tests/test_sync_engine_transcript_live_updates.py -q` -> 2 passed.
+- Runtime bootstrap caveat:
+  - `python -m pytest backend/tests/test_runtime_bootstrap.py -q` segfaulted during pytest collection.
+  - `PYTEST_ADDOPTS=--assert=plain python -m pytest backend/tests/test_runtime_bootstrap.py -q` also segfaulted during collection/import.
+  - `python -m py_compile backend/tests/test_runtime_bootstrap.py` exited with code `-1`, while `python -m py_compile backend/runtime/container.py backend/runtime_ports.py` passed.
+- Result: 55 focused tests passed; the runtime bootstrap test file remains an environment/import caveat rather than evidence of a runtime regression.

--- a/backend/db/sync_engine.py
+++ b/backend/db/sync_engine.py
@@ -48,6 +48,14 @@ from backend.services.session_sentiment_facts import build_session_sentiment_fac
 from backend.services.session_churn_facts import build_session_code_churn_facts
 from backend.services.session_scope_drift import build_session_scope_drift_facts
 from backend.services.session_transcript_projection import project_session_messages
+from backend.services.source_identity import (
+    ProjectId,
+    SourceArtifactKind,
+    SourceIdentityInput,
+    SourceIdentityPolicy,
+    resolve_source_identity,
+    source_identity_policy_from_env,
+)
 from backend.document_linking import (
     alias_tokens_from_path,
     canonical_project_path,
@@ -1260,6 +1268,7 @@ class SyncEngine:
         self._linking_logic_version = str(getattr(config, "LINKING_LOGIC_VERSION", "1")).strip() or "1"
         self._test_source_errors: dict[str, str] = {}
         self._test_source_synced_at: dict[str, str] = {}
+        self._source_identity_policy = source_identity_policy_from_env()
 
     # ── Per-run filesystem traversal cache ─────────────────────────────────
     def _rglob(self, root: Path | str, pattern: str) -> tuple[Path, ...]:
@@ -1276,6 +1285,24 @@ class SyncEngine:
         if key not in self._rglob_cache:
             self._rglob_cache[key] = tuple(root_path.rglob(pattern))
         return self._rglob_cache[key]
+
+    def _canonical_source_key(
+        self,
+        project_id: str,
+        path: Path,
+        artifact_kind: SourceArtifactKind,
+        *,
+        policy: SourceIdentityPolicy | None = None,
+    ) -> str:
+        identity = resolve_source_identity(
+            SourceIdentityInput(
+                project_id=ProjectId(project_id),
+                artifact_kind=artifact_kind,
+                observed_path=path,
+            ),
+            policy or getattr(self, "_source_identity_policy", source_identity_policy_from_env()),
+        )
+        return str(identity.source_key)
 
     def _enterprise_canonical_transcript_authoritative(self) -> bool:
         storage_profile = getattr(config, "STORAGE_PROFILE", None)
@@ -3573,11 +3600,12 @@ class SyncEngine:
         force: bool = False,
     ) -> dict[str, Any]:
         file_path = str(path)
+        sync_file_path = self._canonical_source_key(project_id, path, "test")
         mtime = path.stat().st_mtime
         state_key = self._source_state_key(source)
 
         if not force:
-            cached = await self.sync_repo.get_sync_state(file_path)
+            cached = await self.sync_repo.get_sync_state(sync_file_path)
             if cached and cached["file_mtime"] == mtime:
                 return {"synced": False, "metrics": 0, "errors": []}
 
@@ -3611,7 +3639,7 @@ class SyncEngine:
 
         await self.sync_repo.upsert_sync_state(
             {
-                "file_path": file_path,
+                "file_path": sync_file_path,
                 "file_hash": file_hash,
                 "file_mtime": mtime,
                 "entity_type": f"test_result:{source.platform_id}",
@@ -3821,7 +3849,17 @@ class SyncEngine:
             for index, (change_type, path) in enumerate(changed_files, start=1):
                 if change_type == "deleted":
                     # Remove sync state and associated entities
-                    await self.sync_repo.delete_sync_state(str(path))
+                    if path.suffix == ".jsonl":
+                        sync_state_key = self._canonical_source_key(project_id, path, "session")
+                    elif self._match_source_for_path(resolved_test_sources, path):
+                        sync_state_key = self._canonical_source_key(project_id, path, "test")
+                    elif path.suffix == ".md" and progress_dir in path.parents:
+                        sync_state_key = self._canonical_source_key(project_id, path, "progress")
+                    elif path.suffix == ".md":
+                        sync_state_key = self._canonical_source_key(project_id, path, "document")
+                    else:
+                        sync_state_key = str(path)
+                    await self.sync_repo.delete_sync_state(sync_state_key)
                     if path.suffix == ".jsonl":
                         await self.session_repo.delete_by_source(str(path))
                         stats["sessions"] += 1
@@ -4014,10 +4052,11 @@ class SyncEngine:
     async def _sync_single_session(self, project_id: str, path: Path, force: bool = False) -> bool:
         """Parse and upsert a single session file. Returns True if actually synced."""
         file_path = str(path)
+        sync_file_path = self._canonical_source_key(project_id, path, "session")
         mtime = path.stat().st_mtime
 
         if not force:
-            cached = await self.sync_repo.get_sync_state(file_path)
+            cached = await self.sync_repo.get_sync_state(sync_file_path)
             if cached and cached["file_mtime"] == mtime:
                 needs_lineage_backfill = await self._session_source_needs_lineage_backfill(file_path)
                 if not needs_lineage_backfill:
@@ -4236,7 +4275,7 @@ class SyncEngine:
 
         # Update sync state
         await self.sync_repo.upsert_sync_state({
-            "file_path": file_path,
+            "file_path": sync_file_path,
             "file_hash": _file_hash(path),
             "file_mtime": mtime,
             "entity_type": "session",
@@ -4393,10 +4432,11 @@ class SyncEngine:
         dirty_paths: set[str] | None = None,
     ) -> bool:
         file_path = str(path)
+        sync_file_path = self._canonical_source_key(project_id, path, "document")
         mtime = path.stat().st_mtime
 
         if not force:
-            cached = await self.sync_repo.get_sync_state(file_path)
+            cached = await self.sync_repo.get_sync_state(sync_file_path)
             if cached and cached["file_mtime"] == mtime:
                 return False
 
@@ -4437,7 +4477,7 @@ class SyncEngine:
                     await self.tag_repo.tag_entity("document", doc.id, tag_id)
 
         await self.sync_repo.upsert_sync_state({
-            "file_path": file_path,
+            "file_path": sync_file_path,
             "file_hash": _file_hash(path),
             "file_mtime": mtime,
             "entity_type": "document",
@@ -4486,11 +4526,12 @@ class SyncEngine:
         self, project_id: str, path: Path, progress_dir: Path, force: bool = False,
     ) -> bool:
         file_path = str(path)
+        sync_file_path = self._canonical_source_key(project_id, path, "progress")
         canonical_source = _canonical_task_source(path, progress_dir)
         mtime = path.stat().st_mtime
 
         if not force:
-            cached = await self.sync_repo.get_sync_state(file_path)
+            cached = await self.sync_repo.get_sync_state(sync_file_path)
             if cached and cached["file_mtime"] == mtime:
                 return False
 
@@ -4528,7 +4569,7 @@ class SyncEngine:
                     await self.tag_repo.tag_entity("task", task.id, tag_id)
 
         await self.sync_repo.upsert_sync_state({
-            "file_path": file_path,
+            "file_path": sync_file_path,
             "file_hash": _file_hash(path),
             "file_mtime": mtime,
             "entity_type": "task",

--- a/backend/db/sync_engine.py
+++ b/backend/db/sync_engine.py
@@ -4058,7 +4058,7 @@ class SyncEngine:
         if not force:
             cached = await self.sync_repo.get_sync_state(sync_file_path)
             if cached and cached["file_mtime"] == mtime:
-                needs_lineage_backfill = await self._session_source_needs_lineage_backfill(file_path)
+                needs_lineage_backfill = await self._session_source_needs_lineage_backfill(sync_file_path)
                 if not needs_lineage_backfill:
                     return False  # unchanged
                 logger.info("Session lineage backfill triggered for unchanged file: %s", file_path)
@@ -4088,8 +4088,8 @@ class SyncEngine:
                 "ccdash.file_path": file_path,
             },
         ):
-            await self.session_repo.delete_by_source(file_path)
-            await self.session_repo.delete_relationships_for_source(project_id, file_path)
+            await self.session_repo.delete_by_source(sync_file_path)
+            await self.session_repo.delete_relationships_for_source(project_id, sync_file_path)
 
             if session:
                 all_relationships: list[dict[str, Any]] = []
@@ -4103,7 +4103,12 @@ class SyncEngine:
                         for row in relationship_rows:
                             if isinstance(row, dict):
                                 all_relationships.append(dict(row))
-                    session_payload["sourceFile"] = file_path
+                    session_payload["sourceFile"] = sync_file_path
+                    session_forensics = session_payload.get("sessionForensics")
+                    if not isinstance(session_forensics, dict):
+                        session_forensics = {}
+                    session_forensics.setdefault("observedSourceFile", file_path)
+                    session_payload["sessionForensics"] = session_forensics
                     _apply_claude_usage_fields(session_payload)
                     pending_sessions.append(session_payload)
                     if isinstance(derived_sessions, list):
@@ -4269,7 +4274,7 @@ class SyncEngine:
                 if deduped_relationships:
                     await self.session_repo.upsert_relationships(
                         project_id,
-                        file_path,
+                        sync_file_path,
                         list(deduped_relationships.values()),
                     )
 

--- a/backend/scripts/source_alias_duplicate_audit.py
+++ b/backend/scripts/source_alias_duplicate_audit.py
@@ -119,6 +119,17 @@ class SourceCollapsePlan:
         return tuple(path for path in self.source_paths if path not in survivor_paths)
 
 
+@dataclass(frozen=True, slots=True)
+class CollapseApplyResult:
+    project_id: str
+    planned_groups: int
+    sync_state_upserts: int
+    sync_state_deletes: int
+    session_updates: int
+    relationship_updates: int
+    applied: bool
+
+
 COLLAPSE_STRATEGY = """
 Source alias collapse strategy:
 
@@ -566,6 +577,219 @@ def build_source_collapse_plans(
     return plans
 
 
+def collapse_plans_as_dict(plans: Iterable[SourceCollapsePlan]) -> list[dict[str, Any]]:
+    payload: list[dict[str, Any]] = []
+    for plan in plans:
+        payload.append(
+            {
+                "sourceKey": plan.source_key,
+                "sourcePaths": list(plan.source_paths),
+                "syncStateSurvivor": (
+                    {
+                        "sourcePath": plan.sync_state_survivor.source_path,
+                        "fileHash": plan.sync_state_survivor.file_hash,
+                        "fileMtime": plan.sync_state_survivor.file_mtime,
+                        "lastSynced": plan.sync_state_survivor.last_synced,
+                        "parseMs": plan.sync_state_survivor.parse_ms,
+                    }
+                    if plan.sync_state_survivor
+                    else None
+                ),
+                "sessionSurvivor": (
+                    {
+                        "sourcePath": plan.session_survivor.source_path,
+                        "sessionCount": plan.session_survivor.session_count,
+                        "updatedAt": plan.session_survivor.updated_at,
+                        "canonicalMessageCount": plan.session_survivor.canonical_message_count,
+                        "usageEventCount": plan.session_survivor.usage_event_count,
+                        "telemetryEventCount": plan.session_survivor.telemetry_event_count,
+                        "lineageCompleteCount": plan.session_survivor.lineage_complete_count,
+                    }
+                    if plan.session_survivor
+                    else None
+                ),
+                "actions": list(plan.actions),
+            }
+        )
+    return payload
+
+
+def render_collapse_plan_report(plans: Iterable[SourceCollapsePlan], *, limit: int = 50) -> str:
+    items = list(plans)
+    lines = [
+        "Source alias collapse dry run",
+        f"Planned groups: {len(items)}",
+        "",
+        COLLAPSE_STRATEGY,
+    ]
+    if not items:
+        lines.extend(["", "No duplicate source alias groups require collapse."])
+        return "\n".join(lines)
+
+    safe_limit = max(1, int(limit or 50))
+    lines.extend(["", "Planned source groups:"])
+    for idx, plan in enumerate(items[:safe_limit], start=1):
+        lines.append(f"  {idx:02d}. {plan.source_key}")
+        for path in plan.source_paths:
+            lines.append(f"      sourcePath={path}")
+        if plan.sync_state_survivor:
+            lines.append(
+                "      syncStateSurvivor="
+                f"{plan.sync_state_survivor.source_path} "
+                f"mtime={plan.sync_state_survivor.file_mtime} "
+                f"lastSynced={plan.sync_state_survivor.last_synced}"
+            )
+        if plan.session_survivor:
+            lines.append(
+                "      sessionSurvivor="
+                f"{plan.session_survivor.source_path} "
+                f"sessions={plan.session_survivor.session_count} "
+                f"messages={plan.session_survivor.canonical_message_count}"
+            )
+    remaining = len(items) - safe_limit
+    if remaining > 0:
+        lines.append(f"  ... {remaining} more groups omitted by --limit")
+    return "\n".join(lines)
+
+
+def _parse_execute_count(result: str) -> int:
+    try:
+        return int(str(result).split()[-1])
+    except (IndexError, ValueError):
+        return 0
+
+
+async def apply_source_collapse_plans(
+    conn: Any,
+    *,
+    project_id: str,
+    plans: Iterable[SourceCollapsePlan],
+    apply: bool,
+) -> CollapseApplyResult:
+    items = list(plans)
+    if not apply:
+        return CollapseApplyResult(
+            project_id=project_id,
+            planned_groups=len(items),
+            sync_state_upserts=sum(1 for item in items if item.sync_state_survivor is not None),
+            sync_state_deletes=sum(
+                len([path for path in item.source_paths if path != item.source_key])
+                for item in items
+            ),
+            session_updates=sum(
+                item.session_survivor.session_count if item.session_survivor else 0
+                for item in items
+            ),
+            relationship_updates=0,
+            applied=False,
+        )
+
+    sync_state_upserts = 0
+    sync_state_deletes = 0
+    session_updates = 0
+    relationship_updates = 0
+    for plan in items:
+        alias_paths = [path for path in plan.source_paths if path != plan.source_key]
+        if plan.sync_state_survivor is not None:
+            await conn.execute(
+                """
+                INSERT INTO sync_state (
+                    file_path, file_hash, file_mtime, entity_type,
+                    project_id, last_synced, parse_ms
+                ) VALUES ($1, $2, $3, 'session', $4, $5, $6)
+                ON CONFLICT(file_path) DO UPDATE SET
+                    file_hash = EXCLUDED.file_hash,
+                    file_mtime = EXCLUDED.file_mtime,
+                    entity_type = EXCLUDED.entity_type,
+                    project_id = EXCLUDED.project_id,
+                    last_synced = EXCLUDED.last_synced,
+                    parse_ms = EXCLUDED.parse_ms
+                """,
+                plan.source_key,
+                plan.sync_state_survivor.file_hash,
+                float(plan.sync_state_survivor.file_mtime),
+                project_id,
+                plan.sync_state_survivor.last_synced,
+                int(plan.sync_state_survivor.parse_ms),
+            )
+            sync_state_upserts += 1
+        if alias_paths:
+            deleted = await conn.execute(
+                """
+                DELETE FROM sync_state
+                WHERE project_id = $1
+                  AND entity_type = 'session'
+                  AND file_path = ANY($2::text[])
+                """,
+                project_id,
+                alias_paths,
+            )
+            sync_state_deletes += _parse_execute_count(deleted)
+            updated_sessions = await conn.execute(
+                """
+                UPDATE sessions
+                SET source_file = $1
+                WHERE project_id = $2
+                  AND source_file = ANY($3::text[])
+                  AND source_file <> $1
+                """,
+                plan.source_key,
+                project_id,
+                alias_paths,
+            )
+            session_updates += _parse_execute_count(updated_sessions)
+            updated_relationships = await conn.execute(
+                """
+                UPDATE session_relationships
+                SET source_file = $1
+                WHERE project_id = $2
+                  AND source_file = ANY($3::text[])
+                  AND source_file <> $1
+                """,
+                plan.source_key,
+                project_id,
+                alias_paths,
+            )
+            relationship_updates += _parse_execute_count(updated_relationships)
+
+    return CollapseApplyResult(
+        project_id=project_id,
+        planned_groups=len(items),
+        sync_state_upserts=sync_state_upserts,
+        sync_state_deletes=sync_state_deletes,
+        session_updates=session_updates,
+        relationship_updates=relationship_updates,
+        applied=True,
+    )
+
+
+def collapse_apply_result_as_dict(result: CollapseApplyResult) -> dict[str, Any]:
+    return {
+        "projectId": result.project_id,
+        "plannedGroups": result.planned_groups,
+        "syncStateUpserts": result.sync_state_upserts,
+        "syncStateDeletes": result.sync_state_deletes,
+        "sessionUpdates": result.session_updates,
+        "relationshipUpdates": result.relationship_updates,
+        "applied": result.applied,
+    }
+
+
+def render_collapse_apply_result(result: CollapseApplyResult) -> str:
+    mode = "applied" if result.applied else "dry-run"
+    return "\n".join(
+        [
+            f"Project: {result.project_id}",
+            f"Mode: {mode}",
+            f"Planned groups: {result.planned_groups}",
+            f"sync_state upserts: {result.sync_state_upserts}",
+            f"sync_state deletes: {result.sync_state_deletes}",
+            f"sessions updated: {result.session_updates}",
+            f"session_relationships updated: {result.relationship_updates}",
+        ]
+    )
+
+
 def report_as_dict(report: DuplicateAuditReport) -> dict[str, Any]:
     return {
         "projectId": report.project_id,
@@ -666,6 +890,158 @@ async def fetch_audit_rows(database_url: str, project_id: str) -> list[SourceAud
         await conn.close()
 
 
+async def fetch_collapse_candidates(conn: Any, project_id: str) -> tuple[list[SyncStateCandidate], list[SessionSourceCandidate]]:
+    sync_rows = await conn.fetch(
+        """
+        SELECT
+            file_path,
+            file_hash,
+            file_mtime,
+            last_synced,
+            parse_ms,
+            COUNT(*)::bigint AS row_count
+        FROM sync_state
+        WHERE project_id = $1
+          AND entity_type = 'session'
+          AND COALESCE(file_path, '') != ''
+        GROUP BY file_path, file_hash, file_mtime, last_synced, parse_ms
+        """,
+        project_id,
+    )
+    session_rows = await conn.fetch(
+        """
+        WITH sessions_by_source AS (
+            SELECT
+                source_file,
+                COUNT(*)::bigint AS session_count,
+                MAX(updated_at) AS updated_at,
+                SUM(
+                    CASE
+                        WHEN COALESCE(thread_kind, '') != ''
+                         AND COALESCE(conversation_family_id, '') != ''
+                        THEN 1 ELSE 0
+                    END
+                )::bigint AS lineage_complete_count
+            FROM sessions
+            WHERE project_id = $1
+              AND COALESCE(source_file, '') != ''
+            GROUP BY source_file
+        ),
+        messages_by_source AS (
+            SELECT s.source_file, COUNT(sm.*)::bigint AS canonical_message_count
+            FROM sessions s
+            JOIN session_messages sm ON sm.session_id = s.id
+            WHERE s.project_id = $1
+              AND COALESCE(s.source_file, '') != ''
+            GROUP BY s.source_file
+        ),
+        usage_by_source AS (
+            SELECT s.source_file, COUNT(sue.*)::bigint AS usage_event_count
+            FROM sessions s
+            JOIN session_usage_events sue ON sue.session_id = s.id
+            WHERE s.project_id = $1
+              AND COALESCE(s.source_file, '') != ''
+            GROUP BY s.source_file
+        ),
+        telemetry_by_source AS (
+            SELECT s.source_file, COUNT(te.*)::bigint AS telemetry_event_count
+            FROM sessions s
+            JOIN telemetry_events te ON te.session_id = s.id
+            WHERE s.project_id = $1
+              AND COALESCE(s.source_file, '') != ''
+            GROUP BY s.source_file
+        )
+        SELECT
+            s.source_file,
+            s.session_count,
+            COALESCE(s.updated_at, '') AS updated_at,
+            COALESCE(m.canonical_message_count, 0)::bigint AS canonical_message_count,
+            COALESCE(u.usage_event_count, 0)::bigint AS usage_event_count,
+            COALESCE(t.telemetry_event_count, 0)::bigint AS telemetry_event_count,
+            COALESCE(s.lineage_complete_count, 0)::bigint AS lineage_complete_count
+        FROM sessions_by_source s
+        LEFT JOIN messages_by_source m ON m.source_file = s.source_file
+        LEFT JOIN usage_by_source u ON u.source_file = s.source_file
+        LEFT JOIN telemetry_by_source t ON t.source_file = s.source_file
+        """,
+        project_id,
+    )
+    return (
+        [
+            SyncStateCandidate(
+                source_path=str(row["file_path"]),
+                file_hash=str(row["file_hash"] or ""),
+                file_mtime=float(row["file_mtime"] or 0.0),
+                last_synced=str(row["last_synced"] or ""),
+                parse_ms=int(row["parse_ms"] or 0),
+                row_count=int(row["row_count"] or 0),
+            )
+            for row in sync_rows
+        ],
+        [
+            SessionSourceCandidate(
+                source_path=str(row["source_file"]),
+                session_count=int(row["session_count"] or 0),
+                updated_at=str(row["updated_at"] or ""),
+                canonical_message_count=int(row["canonical_message_count"] or 0),
+                usage_event_count=int(row["usage_event_count"] or 0),
+                telemetry_event_count=int(row["telemetry_event_count"] or 0),
+                lineage_complete_count=int(row["lineage_complete_count"] or 0),
+            )
+            for row in session_rows
+        ],
+    )
+
+
+async def fetch_collapse_plans(
+    *,
+    database_url: str,
+    project_id: str,
+    policy: SourceIdentityPolicy,
+) -> list[SourceCollapsePlan]:
+    import asyncpg
+
+    conn = await asyncpg.connect(database_url)
+    try:
+        sync_candidates, session_candidates = await fetch_collapse_candidates(conn, project_id)
+        return build_source_collapse_plans(
+            project_id=project_id,
+            policy=policy,
+            sync_state_candidates=sync_candidates,
+            session_candidates=session_candidates,
+        )
+    finally:
+        await conn.close()
+
+
+async def apply_collapse_to_database(
+    *,
+    database_url: str,
+    project_id: str,
+    policy: SourceIdentityPolicy,
+) -> CollapseApplyResult:
+    import asyncpg
+
+    conn = await asyncpg.connect(database_url)
+    try:
+        async with conn.transaction():
+            sync_candidates, session_candidates = await fetch_collapse_candidates(conn, project_id)
+            plans = build_source_collapse_plans(
+                project_id=project_id,
+                policy=policy,
+                sync_state_candidates=sync_candidates,
+                session_candidates=session_candidates,
+            )
+            return await apply_source_collapse_plans(
+                conn,
+                project_id=project_id,
+                plans=plans,
+                apply=True,
+            )
+    finally:
+        await conn.close()
+
+
 async def _run(args: argparse.Namespace) -> int:
     env: Mapping[str, str] = os.environ
     if args.env_file:
@@ -673,18 +1049,59 @@ async def _run(args: argparse.Namespace) -> int:
         values.update(load_env_file(args.env_file))
         env = values
 
+    if args.strategy:
+        print(COLLAPSE_STRATEGY)
+        return 0
+
     database_url = args.database_url or env.get("CCDASH_DATABASE_URL") or ""
     if not database_url:
         print("Missing database URL. Set CCDASH_DATABASE_URL or pass --database-url.")
         return 1
 
     try:
+        policy = source_identity_policy_from_env(env)
+        if args.collapse_plan or args.apply_collapse:
+            if args.apply_collapse:
+                result = await apply_collapse_to_database(
+                    database_url=database_url,
+                    project_id=args.project,
+                    policy=policy,
+                )
+                if args.json:
+                    print(json.dumps(collapse_apply_result_as_dict(result), indent=2))
+                else:
+                    print(render_collapse_apply_result(result))
+                return 0
+
+            plans = await fetch_collapse_plans(
+                database_url=database_url,
+                project_id=args.project,
+                policy=policy,
+            )
+            dry_run = await apply_source_collapse_plans(
+                None,
+                project_id=args.project,
+                plans=plans,
+                apply=False,
+            )
+            if args.json:
+                print(
+                    json.dumps(
+                        {
+                            "apply": collapse_apply_result_as_dict(dry_run),
+                            "plans": collapse_plans_as_dict(plans),
+                        },
+                        indent=2,
+                    )
+                )
+            else:
+                print(render_collapse_apply_result(dry_run))
+                print("")
+                print(render_collapse_plan_report(plans, limit=args.limit))
+            return 0
+
         rows = await fetch_audit_rows(database_url, args.project)
-        report = build_duplicate_audit_report(
-            project_id=args.project,
-            rows=rows,
-            policy=source_identity_policy_from_env(env),
-        )
+        report = build_duplicate_audit_report(project_id=args.project, rows=rows, policy=policy)
     except Exception as exc:
         print(f"Duplicate audit query failed: {exc}")
         return 1
@@ -703,6 +1120,9 @@ def main() -> int:
     parser.add_argument("--env-file", default="", help="Optional env file with source alias root settings.")
     parser.add_argument("--limit", type=int, default=50, help="Maximum duplicate groups to print in text output.")
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    parser.add_argument("--strategy", action="store_true", help="Print the collapse strategy and exit.")
+    parser.add_argument("--collapse-plan", action="store_true", help="Print dry-run source alias collapse actions.")
+    parser.add_argument("--apply-collapse", action="store_true", help="Apply source alias collapse in one transaction.")
     args = parser.parse_args()
     return asyncio.run(_run(args))
 

--- a/backend/scripts/source_alias_duplicate_audit.py
+++ b/backend/scripts/source_alias_duplicate_audit.py
@@ -1,0 +1,547 @@
+#!/usr/bin/env python3
+"""Audit host/container source alias duplicates for live-ingest session state.
+
+Usage:
+  python backend/scripts/source_alias_duplicate_audit.py --project default-skillmeat
+  python backend/scripts/source_alias_duplicate_audit.py --project default-skillmeat --env-file deploy/runtime/.env
+  python backend/scripts/source_alias_duplicate_audit.py --project default-skillmeat --json
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable, Mapping
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from backend.services.source_identity import (
+    SOURCE_KEY_SCHEME,
+    SOURCE_KEY_VERSION,
+    ProjectId,
+    SourceArtifactKind,
+    SourceIdentityInput,
+    SourceIdentityPolicy,
+    SourceRootAlias,
+    resolve_source_identity,
+    source_identity_policy_from_env,
+)
+
+
+CANONICAL_SOURCE_PREFIX = f"{SOURCE_KEY_SCHEME}:{SOURCE_KEY_VERSION}/"
+
+
+@dataclass(frozen=True, slots=True)
+class AuditQuerySpec:
+    table_name: str
+    sql: str
+
+
+@dataclass(frozen=True, slots=True)
+class SourceAuditRow:
+    table_name: str
+    source_path: str
+    row_count: int
+
+
+@dataclass(slots=True)
+class DuplicateSourceGroup:
+    source_key: str
+    source_paths: list[str] = field(default_factory=list)
+    table_counts: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def total_rows(self) -> int:
+        return sum(self.table_counts.values())
+
+
+@dataclass(frozen=True, slots=True)
+class AliasPathSummary:
+    table_name: str
+    root_id: str
+    alias_path: str
+    row_count: int
+
+
+@dataclass(slots=True)
+class DuplicateAuditReport:
+    project_id: str
+    duplicate_groups: list[DuplicateSourceGroup]
+    alias_path_summaries: list[AliasPathSummary]
+    table_totals: dict[str, int]
+
+    @property
+    def duplicate_group_count(self) -> int:
+        return len(self.duplicate_groups)
+
+
+AUDIT_QUERY_SPECS: tuple[AuditQuerySpec, ...] = (
+    AuditQuerySpec(
+        table_name="sync_state",
+        sql="""
+            SELECT
+                'sync_state' AS table_name,
+                file_path AS source_path,
+                COUNT(*)::bigint AS row_count
+            FROM sync_state
+            WHERE project_id = $1
+              AND entity_type = 'session'
+              AND COALESCE(file_path, '') != ''
+            GROUP BY file_path
+        """,
+    ),
+    AuditQuerySpec(
+        table_name="sessions",
+        sql="""
+            SELECT
+                'sessions' AS table_name,
+                source_file AS source_path,
+                COUNT(*)::bigint AS row_count
+            FROM sessions
+            WHERE project_id = $1
+              AND COALESCE(source_file, '') != ''
+            GROUP BY source_file
+        """,
+    ),
+    AuditQuerySpec(
+        table_name="session_logs",
+        sql="""
+            SELECT
+                'session_logs' AS table_name,
+                s.source_file AS source_path,
+                COUNT(*)::bigint AS row_count
+            FROM sessions s
+            JOIN session_logs sl ON sl.session_id = s.id
+            WHERE s.project_id = $1
+              AND COALESCE(s.source_file, '') != ''
+            GROUP BY s.source_file
+        """,
+    ),
+    AuditQuerySpec(
+        table_name="session_messages",
+        sql="""
+            SELECT
+                'session_messages' AS table_name,
+                s.source_file AS source_path,
+                COUNT(*)::bigint AS row_count
+            FROM sessions s
+            JOIN session_messages sm ON sm.session_id = s.id
+            WHERE s.project_id = $1
+              AND COALESCE(s.source_file, '') != ''
+            GROUP BY s.source_file
+        """,
+    ),
+    AuditQuerySpec(
+        table_name="session_tool_usage",
+        sql="""
+            SELECT
+                'session_tool_usage' AS table_name,
+                s.source_file AS source_path,
+                COUNT(*)::bigint AS row_count
+            FROM sessions s
+            JOIN session_tool_usage stu ON stu.session_id = s.id
+            WHERE s.project_id = $1
+              AND COALESCE(s.source_file, '') != ''
+            GROUP BY s.source_file
+        """,
+    ),
+    AuditQuerySpec(
+        table_name="session_file_updates",
+        sql="""
+            SELECT
+                'session_file_updates' AS table_name,
+                s.source_file AS source_path,
+                COUNT(*)::bigint AS row_count
+            FROM sessions s
+            JOIN session_file_updates sfu ON sfu.session_id = s.id
+            WHERE s.project_id = $1
+              AND COALESCE(s.source_file, '') != ''
+            GROUP BY s.source_file
+        """,
+    ),
+    AuditQuerySpec(
+        table_name="session_artifacts",
+        sql="""
+            SELECT
+                'session_artifacts' AS table_name,
+                s.source_file AS source_path,
+                COUNT(*)::bigint AS row_count
+            FROM sessions s
+            JOIN session_artifacts sa ON sa.session_id = s.id
+            WHERE s.project_id = $1
+              AND COALESCE(s.source_file, '') != ''
+            GROUP BY s.source_file
+        """,
+    ),
+    AuditQuerySpec(
+        table_name="session_usage_events",
+        sql="""
+            SELECT
+                'session_usage_events' AS table_name,
+                s.source_file AS source_path,
+                COUNT(*)::bigint AS row_count
+            FROM sessions s
+            JOIN session_usage_events sue ON sue.session_id = s.id
+            WHERE s.project_id = $1
+              AND COALESCE(s.source_file, '') != ''
+            GROUP BY s.source_file
+        """,
+    ),
+    AuditQuerySpec(
+        table_name="session_usage_attributions",
+        sql="""
+            SELECT
+                'session_usage_attributions' AS table_name,
+                s.source_file AS source_path,
+                COUNT(*)::bigint AS row_count
+            FROM sessions s
+            JOIN session_usage_events sue ON sue.session_id = s.id
+            JOIN session_usage_attributions sua ON sua.event_id = sue.id
+            WHERE s.project_id = $1
+              AND COALESCE(s.source_file, '') != ''
+            GROUP BY s.source_file
+        """,
+    ),
+    AuditQuerySpec(
+        table_name="session_relationships",
+        sql="""
+            SELECT
+                'session_relationships' AS table_name,
+                source_file AS source_path,
+                COUNT(*)::bigint AS row_count
+            FROM session_relationships
+            WHERE project_id = $1
+              AND COALESCE(source_file, '') != ''
+            GROUP BY source_file
+        """,
+    ),
+    AuditQuerySpec(
+        table_name="telemetry_events",
+        sql="""
+            SELECT
+                'telemetry_events' AS table_name,
+                s.source_file AS source_path,
+                COUNT(*)::bigint AS row_count
+            FROM sessions s
+            JOIN telemetry_events te ON te.session_id = s.id
+            WHERE s.project_id = $1
+              AND COALESCE(s.source_file, '') != ''
+            GROUP BY s.source_file
+        """,
+    ),
+    AuditQuerySpec(
+        table_name="commit_correlations",
+        sql="""
+            SELECT
+                'commit_correlations' AS table_name,
+                s.source_file AS source_path,
+                COUNT(*)::bigint AS row_count
+            FROM sessions s
+            JOIN commit_correlations cc ON cc.session_id = s.id
+            WHERE s.project_id = $1
+              AND COALESCE(s.source_file, '') != ''
+            GROUP BY s.source_file
+        """,
+    ),
+    AuditQuerySpec(
+        table_name="session_sentiment_facts",
+        sql="""
+            SELECT
+                'session_sentiment_facts' AS table_name,
+                s.source_file AS source_path,
+                COUNT(*)::bigint AS row_count
+            FROM sessions s
+            JOIN session_sentiment_facts ssf ON ssf.session_id = s.id
+            WHERE s.project_id = $1
+              AND COALESCE(s.source_file, '') != ''
+            GROUP BY s.source_file
+        """,
+    ),
+    AuditQuerySpec(
+        table_name="session_code_churn_facts",
+        sql="""
+            SELECT
+                'session_code_churn_facts' AS table_name,
+                s.source_file AS source_path,
+                COUNT(*)::bigint AS row_count
+            FROM sessions s
+            JOIN session_code_churn_facts sccf ON sccf.session_id = s.id
+            WHERE s.project_id = $1
+              AND COALESCE(s.source_file, '') != ''
+            GROUP BY s.source_file
+        """,
+    ),
+    AuditQuerySpec(
+        table_name="session_scope_drift_facts",
+        sql="""
+            SELECT
+                'session_scope_drift_facts' AS table_name,
+                s.source_file AS source_path,
+                COUNT(*)::bigint AS row_count
+            FROM sessions s
+            JOIN session_scope_drift_facts ssdf ON ssdf.session_id = s.id
+            WHERE s.project_id = $1
+              AND COALESCE(s.source_file, '') != ''
+            GROUP BY s.source_file
+        """,
+    ),
+)
+
+
+def _canonical_source_key(
+    *,
+    project_id: str,
+    source_path: str,
+    policy: SourceIdentityPolicy,
+    artifact_kind: SourceArtifactKind = "session",
+) -> str:
+    if source_path.startswith(CANONICAL_SOURCE_PREFIX):
+        return source_path
+    identity = resolve_source_identity(
+        SourceIdentityInput(
+            project_id=ProjectId(project_id),
+            observed_path=PurePosixPath(source_path),
+            artifact_kind=artifact_kind,
+        ),
+        policy,
+    )
+    return str(identity.source_key)
+
+
+def _matched_alias(source_path: str, policy: SourceIdentityPolicy) -> SourceRootAlias | None:
+    if source_path.startswith(CANONICAL_SOURCE_PREFIX):
+        return None
+    try:
+        observed = resolve_source_identity(
+            SourceIdentityInput(
+                project_id=ProjectId("_audit"),
+                observed_path=PurePosixPath(source_path),
+                artifact_kind="session",
+            ),
+            policy,
+        )
+    except ValueError:
+        return None
+    if str(observed.root_id) == "opaque":
+        return None
+    aliases = sorted(
+        policy.aliases,
+        key=lambda alias: len(PurePosixPath(str(alias.alias_path)).parts),
+        reverse=True,
+    )
+    for alias in aliases:
+        try:
+            PurePosixPath(source_path).relative_to(alias.alias_path)
+        except ValueError:
+            continue
+        if str(alias.root_id) == str(observed.root_id):
+            return alias
+    return None
+
+
+def build_duplicate_audit_report(
+    *,
+    project_id: str,
+    rows: Iterable[SourceAuditRow],
+    policy: SourceIdentityPolicy,
+) -> DuplicateAuditReport:
+    groups_by_key: dict[str, DuplicateSourceGroup] = {}
+    table_totals: dict[str, int] = {}
+    alias_totals: dict[tuple[str, str, str], int] = {}
+
+    for row in rows:
+        source_path = str(row.source_path or "").strip()
+        if not source_path:
+            continue
+        row_count = int(row.row_count or 0)
+        table_totals[row.table_name] = table_totals.get(row.table_name, 0) + row_count
+        source_key = _canonical_source_key(
+            project_id=project_id,
+            source_path=source_path,
+            policy=policy,
+        )
+        group = groups_by_key.setdefault(source_key, DuplicateSourceGroup(source_key=source_key))
+        if source_path not in group.source_paths:
+            group.source_paths.append(source_path)
+        group.table_counts[row.table_name] = group.table_counts.get(row.table_name, 0) + row_count
+
+        alias = _matched_alias(source_path, policy)
+        if alias is not None:
+            alias_key = (row.table_name, str(alias.root_id), alias.alias_path.as_posix())
+            alias_totals[alias_key] = alias_totals.get(alias_key, 0) + row_count
+
+    duplicate_groups = [
+        group
+        for group in groups_by_key.values()
+        if len(group.source_paths) > 1
+    ]
+    for group in duplicate_groups:
+        group.source_paths.sort()
+    duplicate_groups.sort(key=lambda group: (-group.total_rows, group.source_key))
+
+    alias_path_summaries = [
+        AliasPathSummary(
+            table_name=table_name,
+            root_id=root_id,
+            alias_path=alias_path,
+            row_count=row_count,
+        )
+        for (table_name, root_id, alias_path), row_count in alias_totals.items()
+    ]
+    alias_path_summaries.sort(key=lambda item: (item.table_name, item.root_id, item.alias_path))
+    return DuplicateAuditReport(
+        project_id=project_id,
+        duplicate_groups=duplicate_groups,
+        alias_path_summaries=alias_path_summaries,
+        table_totals=dict(sorted(table_totals.items())),
+    )
+
+
+def report_as_dict(report: DuplicateAuditReport) -> dict[str, Any]:
+    return {
+        "projectId": report.project_id,
+        "duplicateGroupCount": report.duplicate_group_count,
+        "tableTotals": report.table_totals,
+        "aliasPathSummaries": [
+            {
+                "tableName": item.table_name,
+                "rootId": item.root_id,
+                "aliasPath": item.alias_path,
+                "rowCount": item.row_count,
+            }
+            for item in report.alias_path_summaries
+        ],
+        "duplicateGroups": [
+            {
+                "sourceKey": group.source_key,
+                "sourcePaths": group.source_paths,
+                "tableCounts": dict(sorted(group.table_counts.items())),
+                "totalRows": group.total_rows,
+            }
+            for group in report.duplicate_groups
+        ],
+    }
+
+
+def render_text_report(report: DuplicateAuditReport, *, limit: int = 50) -> str:
+    lines = [
+        f"Project: {report.project_id}",
+        f"Duplicate source groups: {report.duplicate_group_count}",
+        "",
+        "Table totals:",
+    ]
+    for table_name, row_count in report.table_totals.items():
+        lines.append(f"  {table_name}: {row_count}")
+
+    if report.alias_path_summaries:
+        lines.extend(["", "Alias path counts:"])
+        for item in report.alias_path_summaries:
+            lines.append(
+                f"  {item.table_name} root={item.root_id} alias={item.alias_path}: {item.row_count}"
+            )
+
+    lines.extend(["", "Duplicate groups:"])
+    if not report.duplicate_groups:
+        lines.append("  none")
+        return "\n".join(lines)
+
+    safe_limit = max(1, int(limit or 50))
+    for idx, group in enumerate(report.duplicate_groups[:safe_limit], start=1):
+        lines.append(f"  {idx:02d}. {group.source_key}")
+        lines.append(f"      totalRows={group.total_rows}")
+        lines.append(
+            "      tableCounts="
+            + ", ".join(f"{name}={count}" for name, count in sorted(group.table_counts.items()))
+        )
+        for source_path in group.source_paths:
+            lines.append(f"      sourcePath={source_path}")
+    remaining = len(report.duplicate_groups) - safe_limit
+    if remaining > 0:
+        lines.append(f"  ... {remaining} more groups omitted by --limit")
+    return "\n".join(lines)
+
+
+def load_env_file(path: str) -> dict[str, str]:
+    values: dict[str, str] = {}
+    with open(path, encoding="utf-8") as handle:
+        for raw_line in handle:
+            line = raw_line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            key = key.strip()
+            value = value.strip().strip("'\"")
+            if key:
+                values[key] = value
+    return values
+
+
+async def fetch_audit_rows(database_url: str, project_id: str) -> list[SourceAuditRow]:
+    import asyncpg
+
+    conn = await asyncpg.connect(database_url)
+    try:
+        rows: list[SourceAuditRow] = []
+        for spec in AUDIT_QUERY_SPECS:
+            fetched = await conn.fetch(spec.sql, project_id)
+            for row in fetched:
+                rows.append(
+                    SourceAuditRow(
+                        table_name=str(row["table_name"]),
+                        source_path=str(row["source_path"]),
+                        row_count=int(row["row_count"]),
+                    )
+                )
+        return rows
+    finally:
+        await conn.close()
+
+
+async def _run(args: argparse.Namespace) -> int:
+    env: Mapping[str, str] = os.environ
+    if args.env_file:
+        values = dict(os.environ)
+        values.update(load_env_file(args.env_file))
+        env = values
+
+    database_url = args.database_url or env.get("CCDASH_DATABASE_URL") or ""
+    if not database_url:
+        print("Missing database URL. Set CCDASH_DATABASE_URL or pass --database-url.")
+        return 1
+
+    try:
+        rows = await fetch_audit_rows(database_url, args.project)
+        report = build_duplicate_audit_report(
+            project_id=args.project,
+            rows=rows,
+            policy=source_identity_policy_from_env(env),
+        )
+    except Exception as exc:
+        print(f"Duplicate audit query failed: {exc}")
+        return 1
+
+    if args.json:
+        print(json.dumps(report_as_dict(report), indent=2))
+    else:
+        print(render_text_report(report, limit=args.limit))
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Audit host/container source alias duplicates.")
+    parser.add_argument("--project", required=True, help="Project ID to audit.")
+    parser.add_argument("--database-url", default="", help="Postgres connection URL. Defaults to CCDASH_DATABASE_URL.")
+    parser.add_argument("--env-file", default="", help="Optional env file with source alias root settings.")
+    parser.add_argument("--limit", type=int, default=50, help="Maximum duplicate groups to print in text output.")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    args = parser.parse_args()
+    return asyncio.run(_run(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/source_alias_duplicate_audit.py
+++ b/backend/scripts/source_alias_duplicate_audit.py
@@ -80,6 +80,64 @@ class DuplicateAuditReport:
         return len(self.duplicate_groups)
 
 
+@dataclass(frozen=True, slots=True)
+class SyncStateCandidate:
+    source_path: str
+    file_hash: str
+    file_mtime: float
+    last_synced: str
+    parse_ms: int
+    row_count: int = 1
+
+
+@dataclass(frozen=True, slots=True)
+class SessionSourceCandidate:
+    source_path: str
+    session_count: int
+    updated_at: str
+    canonical_message_count: int = 0
+    usage_event_count: int = 0
+    telemetry_event_count: int = 0
+    lineage_complete_count: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class SourceCollapsePlan:
+    source_key: str
+    source_paths: tuple[str, ...]
+    sync_state_survivor: SyncStateCandidate | None
+    session_survivor: SessionSourceCandidate | None
+    actions: tuple[str, ...]
+
+    @property
+    def loser_paths(self) -> tuple[str, ...]:
+        survivor_paths = {
+            candidate.source_path
+            for candidate in (self.sync_state_survivor, self.session_survivor)
+            if candidate is not None
+        }
+        return tuple(path for path in self.source_paths if path not in survivor_paths)
+
+
+COLLAPSE_STRATEGY = """
+Source alias collapse strategy:
+
+1. Scope every run by explicit project id and the same SourceIdentityPolicy used
+   by live ingest. Never collapse by suffix-only path matching.
+2. Group legacy host/container source paths by canonical source key.
+3. Choose the sync_state survivor by newest file_mtime, then newest
+   last_synced, then highest parse_ms. Preserve that row's file_hash and mtime
+   when upserting the canonical source key.
+4. Choose the session survivor by transcript completeness first
+   (canonical_message_count), then usage/telemetry evidence, lineage
+   completeness, session_count, and updated_at. The apply path updates source
+   fields to the canonical source key before deleting duplicate sync_state rows.
+5. Apply must run inside one transaction after a dry-run review. Rollback is
+   restoring the Postgres volume backup or transaction snapshot captured before
+   apply.
+""".strip()
+
+
 AUDIT_QUERY_SPECS: tuple[AuditQuerySpec, ...] = (
     AuditQuerySpec(
         table_name="sync_state",
@@ -400,6 +458,112 @@ def build_duplicate_audit_report(
         alias_path_summaries=alias_path_summaries,
         table_totals=dict(sorted(table_totals.items())),
     )
+
+
+def _candidate_canonical_key(
+    *,
+    project_id: str,
+    source_path: str,
+    policy: SourceIdentityPolicy,
+) -> str:
+    return _canonical_source_key(
+        project_id=project_id,
+        source_path=source_path,
+        policy=policy,
+    )
+
+
+def _sync_state_sort_key(candidate: SyncStateCandidate) -> tuple[float, str, int, int, str]:
+    return (
+        float(candidate.file_mtime or 0.0),
+        str(candidate.last_synced or ""),
+        int(candidate.parse_ms or 0),
+        int(candidate.row_count or 0),
+        candidate.source_path,
+    )
+
+
+def _session_source_sort_key(candidate: SessionSourceCandidate) -> tuple[int, int, int, int, int, str, str]:
+    return (
+        int(candidate.canonical_message_count or 0),
+        int(candidate.usage_event_count or 0),
+        int(candidate.telemetry_event_count or 0),
+        int(candidate.lineage_complete_count or 0),
+        int(candidate.session_count or 0),
+        str(candidate.updated_at or ""),
+        candidate.source_path,
+    )
+
+
+def choose_sync_state_survivor(candidates: Iterable[SyncStateCandidate]) -> SyncStateCandidate | None:
+    items = list(candidates)
+    if not items:
+        return None
+    return max(items, key=_sync_state_sort_key)
+
+
+def choose_session_source_survivor(
+    candidates: Iterable[SessionSourceCandidate],
+) -> SessionSourceCandidate | None:
+    items = list(candidates)
+    if not items:
+        return None
+    return max(items, key=_session_source_sort_key)
+
+
+def build_source_collapse_plans(
+    *,
+    project_id: str,
+    policy: SourceIdentityPolicy,
+    sync_state_candidates: Iterable[SyncStateCandidate],
+    session_candidates: Iterable[SessionSourceCandidate],
+) -> list[SourceCollapsePlan]:
+    grouped_sync: dict[str, list[SyncStateCandidate]] = {}
+    grouped_sessions: dict[str, list[SessionSourceCandidate]] = {}
+    source_paths_by_key: dict[str, set[str]] = {}
+
+    for candidate in sync_state_candidates:
+        source_key = _candidate_canonical_key(
+            project_id=project_id,
+            source_path=candidate.source_path,
+            policy=policy,
+        )
+        grouped_sync.setdefault(source_key, []).append(candidate)
+        source_paths_by_key.setdefault(source_key, set()).add(candidate.source_path)
+
+    for candidate in session_candidates:
+        source_key = _candidate_canonical_key(
+            project_id=project_id,
+            source_path=candidate.source_path,
+            policy=policy,
+        )
+        grouped_sessions.setdefault(source_key, []).append(candidate)
+        source_paths_by_key.setdefault(source_key, set()).add(candidate.source_path)
+
+    plans: list[SourceCollapsePlan] = []
+    for source_key, source_paths in source_paths_by_key.items():
+        if len(source_paths) <= 1:
+            continue
+        sync_survivor = choose_sync_state_survivor(grouped_sync.get(source_key, []))
+        session_survivor = choose_session_source_survivor(grouped_sessions.get(source_key, []))
+        ordered_paths = tuple(sorted(source_paths))
+        actions = [
+            "upsert canonical sync_state survivor and delete alias sync_state rows",
+            "update sessions.source_file to canonical source key",
+            "update session_relationships.source_file to canonical source key",
+            "preserve child rows through session_id foreign keys and regenerate telemetry/commit facts on next ingest if needed",
+        ]
+        plans.append(
+            SourceCollapsePlan(
+                source_key=source_key,
+                source_paths=ordered_paths,
+                sync_state_survivor=sync_survivor,
+                session_survivor=session_survivor,
+                actions=tuple(actions),
+            )
+        )
+    plans.sort(key=lambda plan: plan.source_key)
+    return plans
 
 
 def report_as_dict(report: DuplicateAuditReport) -> dict[str, Any]:

--- a/backend/services/source_identity.py
+++ b/backend/services/source_identity.py
@@ -6,10 +6,12 @@ engine or repositories yet.
 """
 from __future__ import annotations
 
+import hashlib
+import os
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import PurePosixPath
-from typing import Literal, NewType
+from typing import Mapping, Literal, NewType
 
 
 SourceKey = NewType("SourceKey", str)
@@ -115,10 +117,6 @@ class SourceIdentityPolicy:
     unknown_path_behavior: SourceAliasBehavior = SourceAliasBehavior.KEEP_OPAQUE
 
 
-class SourceIdentityResolutionPending(NotImplementedError):
-    """Raised while only the SRC-001 contract is implemented."""
-
-
 def format_known_source_key(
     *,
     project_id: ProjectId,
@@ -133,10 +131,57 @@ def format_known_source_key(
     the contract without importing repository or runtime code.
     """
 
-    relative = relative_path.as_posix().lstrip("/")
+    relative = relative_path.as_posix().lstrip("/") or "."
     return SourceKey(
         f"{SOURCE_KEY_SCHEME}:{SOURCE_KEY_VERSION}/"
         f"{project_id}/{artifact_kind}/{root_id}/{relative}"
+    )
+
+
+def _normalize_posix_path(raw: str | PurePosixPath) -> PurePosixPath:
+    text = os.path.expanduser(str(raw)).replace("\\", "/").strip()
+    if not text:
+        raise ValueError("source path cannot be empty")
+
+    is_absolute = text.startswith("/")
+    parts: list[str] = []
+    for part in PurePosixPath(text).parts:
+        if part in ("", "/", "."):
+            continue
+        if part == "..":
+            if parts:
+                parts.pop()
+                continue
+            if is_absolute:
+                raise ValueError(f"source path escapes filesystem root: {raw}")
+            parts.append(part)
+            continue
+        parts.append(part)
+
+    prefix = "/" if is_absolute else ""
+    normalized = prefix + "/".join(parts)
+    if not normalized:
+        normalized = "/" if is_absolute else "."
+    return PurePosixPath(normalized)
+
+
+def _path_relative_to(path: PurePosixPath, root: PurePosixPath) -> PurePosixPath | None:
+    try:
+        return path.relative_to(root)
+    except ValueError:
+        return None
+
+
+def _opaque_source_key(
+    *,
+    project_id: ProjectId,
+    artifact_kind: SourceArtifactKind,
+    observed_path: PurePosixPath,
+) -> SourceKey:
+    digest = hashlib.sha256(observed_path.as_posix().encode("utf-8")).hexdigest()[:32]
+    return SourceKey(
+        f"{SOURCE_KEY_SCHEME}:{SOURCE_KEY_VERSION}/"
+        f"{project_id}/{artifact_kind}/opaque/{digest}"
     )
 
 
@@ -146,15 +191,121 @@ def resolve_source_identity(
 ) -> CanonicalSourceIdentity:
     """Resolve an observed filesystem path to a canonical source identity.
 
-    This is the pure API skeleton for SRC-002. It accepts only data inputs and a
-    policy object, performs no filesystem I/O, and must stay deterministic.
-    Behavior is deliberately pending in SRC-001 to avoid silently introducing
-    repository semantics before the helper tests and sync boundaries are ready.
+    The function performs lexical POSIX normalization only. It does not call
+    ``Path.resolve()``, inspect symlinks, or touch the filesystem, so the same
+    inputs produce the same source key in host and container runtimes.
     """
 
-    raise SourceIdentityResolutionPending(
-        "SRC-001 defines the source identity contract only; SRC-002 implements resolution."
+    observed_path = _normalize_posix_path(source.observed_path)
+    aliases = sorted(
+        policy.aliases,
+        key=lambda alias: len(_normalize_posix_path(alias.alias_path).parts),
+        reverse=True,
     )
+    for alias in aliases:
+        alias_path = _normalize_posix_path(alias.alias_path)
+        relative_path = _path_relative_to(observed_path, alias_path)
+        if relative_path is None:
+            continue
+        if alias.behavior == SourceAliasBehavior.REJECT_ESCAPE:
+            raise ValueError(f"source path matched rejected alias root: {alias_path}")
+        if alias.behavior == SourceAliasBehavior.KEEP_OPAQUE:
+            break
+        return CanonicalSourceIdentity(
+            source_key=format_known_source_key(
+                project_id=source.project_id,
+                artifact_kind=source.artifact_kind,
+                root_id=alias.root_id,
+                relative_path=relative_path,
+            ),
+            project_id=source.project_id,
+            artifact_kind=source.artifact_kind,
+            root_id=alias.root_id,
+            relative_path=relative_path,
+            observed_path=observed_path,
+            alias_behavior=alias.behavior,
+        )
+
+    if policy.unknown_path_behavior == SourceAliasBehavior.REJECT_ESCAPE:
+        raise ValueError(f"source path is outside configured roots: {observed_path}")
+
+    return CanonicalSourceIdentity(
+        source_key=_opaque_source_key(
+            project_id=source.project_id,
+            artifact_kind=source.artifact_kind,
+            observed_path=observed_path,
+        ),
+        project_id=source.project_id,
+        artifact_kind=source.artifact_kind,
+        root_id=SourceRootId("opaque"),
+        relative_path=None,
+        observed_path=observed_path,
+        alias_behavior=SourceAliasBehavior.KEEP_OPAQUE,
+    )
+
+
+def _add_alias_pair(
+    aliases: list[SourceRootAlias],
+    *,
+    root_id: str,
+    first: str | None,
+    second: str | None,
+) -> None:
+    seen: set[str] = {alias.alias_path.as_posix() for alias in aliases}
+    for raw_path in (first, second):
+        if raw_path is None or not str(raw_path).strip():
+            continue
+        alias_path = _normalize_posix_path(raw_path)
+        alias_key = alias_path.as_posix()
+        if alias_key in seen:
+            continue
+        seen.add(alias_key)
+        aliases.append(
+            SourceRootAlias(
+                root_id=SourceRootId(root_id),
+                alias_path=alias_path,
+            )
+        )
+
+
+def source_identity_policy_from_env(
+    env: Mapping[str, str] | None = None,
+) -> SourceIdentityPolicy:
+    """Build runtime mount aliases from CCDash container env variables.
+
+    This convenience builder is deterministic and side-effect free aside from
+    reading ``os.environ`` when no mapping is supplied. It mirrors
+    ``deploy/runtime/compose.yaml`` mount pairs.
+    """
+
+    values = os.environ if env is None else env
+    aliases: list[SourceRootAlias] = []
+    _add_alias_pair(
+        aliases,
+        root_id="workspace",
+        first=values.get("CCDASH_WORKSPACE_HOST_ROOT"),
+        second=values.get("CCDASH_WORKSPACE_CONTAINER_ROOT"),
+    )
+    _add_alias_pair(
+        aliases,
+        root_id="claude_home",
+        first=values.get("CCDASH_CLAUDE_HOME"),
+        second=values.get("CCDASH_CLAUDE_CONTAINER_HOME"),
+    )
+    _add_alias_pair(
+        aliases,
+        root_id="codex_home",
+        first=values.get("CCDASH_CODEX_HOME"),
+        second=values.get("CCDASH_CODEX_CONTAINER_HOME"),
+    )
+    for slot in range(1, 7):
+        _add_alias_pair(
+            aliases,
+            root_id=f"extra_mount_{slot}",
+            first=values.get(f"CCDASH_EXTRA_MOUNT_{slot}_HOST"),
+            second=values.get(f"CCDASH_EXTRA_MOUNT_{slot}_CONTAINER"),
+        )
+    return SourceIdentityPolicy(aliases=tuple(aliases))
 
 
 __all__ = [
@@ -166,10 +317,10 @@ __all__ = [
     "SourceArtifactKind",
     "SourceIdentityInput",
     "SourceIdentityPolicy",
-    "SourceIdentityResolutionPending",
     "SourceKey",
     "SourceRootAlias",
     "SourceRootId",
     "format_known_source_key",
     "resolve_source_identity",
+    "source_identity_policy_from_env",
 ]

--- a/backend/services/source_identity.py
+++ b/backend/services/source_identity.py
@@ -1,0 +1,175 @@
+"""Filesystem-derived source identity contract.
+
+This module defines the Phase 1 contract for canonical source keys used by
+later live-ingest hardening work. It intentionally does not wire the sync
+engine or repositories yet.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import PurePosixPath
+from typing import Literal, NewType
+
+
+SourceKey = NewType("SourceKey", str)
+ProjectId = NewType("ProjectId", str)
+SourceRootId = NewType("SourceRootId", str)
+
+SourceArtifactKind = Literal["session", "document", "progress", "test", "unknown"]
+
+SOURCE_KEY_SCHEME = "ccdash-source"
+SOURCE_KEY_VERSION = "v1"
+
+
+class SourceAliasBehavior(str, Enum):
+    """How an observed path should be treated when resolving source identity."""
+
+    COLLAPSE_TO_ROOT = "collapse_to_root"
+    KEEP_OPAQUE = "keep_opaque"
+    REJECT_ESCAPE = "reject_escape"
+
+
+@dataclass(frozen=True, slots=True)
+class SourceRootAlias:
+    """Configured alias for the same logical filesystem root.
+
+    Inputs:
+        root_id: Stable root token scoped by project configuration, such as
+            ``claude_home``, ``codex_home``, ``workspace``, or an optional
+            mount slot id like ``extra_mount_1``.
+        alias_path: Absolute host or container path for that root. Examples
+            include ``/Users/miethe/.claude`` and ``/home/ccdash/.claude``.
+        behavior: ``COLLAPSE_TO_ROOT`` means files below this alias may share
+            source keys with other aliases for the same ``root_id``.
+
+    Rollout constraint:
+        Alias configuration must come from project/runtime registry data, not
+        broad ad hoc suffix replacement. A container path and host path only
+        collapse when they are explicit aliases for the same ``root_id``.
+    """
+
+    root_id: SourceRootId
+    alias_path: PurePosixPath
+    behavior: SourceAliasBehavior = SourceAliasBehavior.COLLAPSE_TO_ROOT
+
+
+@dataclass(frozen=True, slots=True)
+class SourceIdentityInput:
+    """Observed filesystem source identity inputs.
+
+    ``observed_path`` is the raw path seen by the active runtime. It may be a
+    host path, container path, symlink-resolved path, or optional mount path.
+    ``project_id`` is always part of the identity boundary so unrelated
+    projects cannot collide when they share root ids or relative paths.
+    """
+
+    project_id: ProjectId
+    observed_path: PurePosixPath
+    artifact_kind: SourceArtifactKind
+    runtime_label: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalSourceIdentity:
+    """Resolved canonical source identity.
+
+    Output format:
+        Known-root keys use
+        ``ccdash-source:v1/{project_id}/{artifact_kind}/{root_id}/{relative_path}``.
+        Unknown or intentionally opaque paths use the same scheme with an
+        opaque root token and a digest-like terminal component supplied by the
+        future helper implementation.
+
+    Alias behavior:
+        Host/container aliases for the same configured root collapse to the
+        same key. Unknown paths remain stable but do not collapse across roots
+        or projects. Escapes such as ``..`` outside a known root must be
+        rejected instead of normalized into a neighboring root.
+
+    Rollout constraint:
+        Persistence code should use ``source_key`` for lookup/write/delete
+        boundaries while preserving ``observed_path`` or another display path
+        for debugging and UI compatibility.
+    """
+
+    source_key: SourceKey
+    project_id: ProjectId
+    artifact_kind: SourceArtifactKind
+    root_id: SourceRootId
+    relative_path: PurePosixPath | None
+    observed_path: PurePosixPath
+    alias_behavior: SourceAliasBehavior
+
+
+@dataclass(frozen=True, slots=True)
+class SourceIdentityPolicy:
+    """Pure policy bundle for resolving canonical source identity.
+
+    Later implementation tasks will populate this from project registry paths,
+    ``~/.claude`` and ``~/.codex`` roots, container home remaps, and optional
+    runtime mount slots.
+    """
+
+    aliases: tuple[SourceRootAlias, ...] = field(default_factory=tuple)
+    unknown_path_behavior: SourceAliasBehavior = SourceAliasBehavior.KEEP_OPAQUE
+
+
+class SourceIdentityResolutionPending(NotImplementedError):
+    """Raised while only the SRC-001 contract is implemented."""
+
+
+def format_known_source_key(
+    *,
+    project_id: ProjectId,
+    artifact_kind: SourceArtifactKind,
+    root_id: SourceRootId,
+    relative_path: PurePosixPath,
+) -> SourceKey:
+    """Format a canonical known-root source key.
+
+    The caller must provide an already validated relative POSIX path. This
+    helper is intentionally small and side-effect free so later tasks can reuse
+    the contract without importing repository or runtime code.
+    """
+
+    relative = relative_path.as_posix().lstrip("/")
+    return SourceKey(
+        f"{SOURCE_KEY_SCHEME}:{SOURCE_KEY_VERSION}/"
+        f"{project_id}/{artifact_kind}/{root_id}/{relative}"
+    )
+
+
+def resolve_source_identity(
+    source: SourceIdentityInput,
+    policy: SourceIdentityPolicy,
+) -> CanonicalSourceIdentity:
+    """Resolve an observed filesystem path to a canonical source identity.
+
+    This is the pure API skeleton for SRC-002. It accepts only data inputs and a
+    policy object, performs no filesystem I/O, and must stay deterministic.
+    Behavior is deliberately pending in SRC-001 to avoid silently introducing
+    repository semantics before the helper tests and sync boundaries are ready.
+    """
+
+    raise SourceIdentityResolutionPending(
+        "SRC-001 defines the source identity contract only; SRC-002 implements resolution."
+    )
+
+
+__all__ = [
+    "CanonicalSourceIdentity",
+    "ProjectId",
+    "SOURCE_KEY_SCHEME",
+    "SOURCE_KEY_VERSION",
+    "SourceAliasBehavior",
+    "SourceArtifactKind",
+    "SourceIdentityInput",
+    "SourceIdentityPolicy",
+    "SourceIdentityResolutionPending",
+    "SourceKey",
+    "SourceRootAlias",
+    "SourceRootId",
+    "format_known_source_key",
+    "resolve_source_identity",
+]

--- a/backend/tests/test_file_watcher.py
+++ b/backend/tests/test_file_watcher.py
@@ -15,6 +15,7 @@ from backend.db.sqlite_migrations import run_migrations
 from backend.db.sync_engine import SyncEngine
 from backend.runtime.profiles import get_runtime_profile
 from backend.runtime.storage_contract import get_runtime_storage_contract
+from backend.services.source_identity import SourceIdentityPolicy, SourceRootAlias, SourceRootId
 from backend.services.test_config import ResolvedTestSource
 
 
@@ -212,7 +213,7 @@ class JsonlAppendIncrementalSyncTests(unittest.IsolatedAsyncioTestCase):
             messages = await engine.session_message_repo.list_by_session(session_id)
             async with self.db.execute(
                 "SELECT file_mtime FROM sync_state WHERE file_path = ?",
-                (str(session_path),),
+                (engine._canonical_source_key("project-1", session_path, "session"),),
             ) as cur:
                 sync_state = await cur.fetchone()
 
@@ -221,6 +222,84 @@ class JsonlAppendIncrementalSyncTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual([message["content"] for message in messages], ["Start the work", "Finished the first step"])
         self.assertIsNotNone(sync_state)
         self.assertGreater(float(sync_state["file_mtime"]), 0)
+
+    async def test_alias_session_reingest_keeps_replace_scoped_tables_stable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            host_sessions = root / "host-sessions"
+            host_sessions.mkdir()
+            container_sessions = root / "container-sessions"
+            container_sessions.symlink_to(host_sessions, target_is_directory=True)
+            docs_dir = root / "docs"
+            progress_dir = root / "progress"
+            docs_dir.mkdir()
+            progress_dir.mkdir()
+
+            session_path = host_sessions / "alias-session.jsonl"
+            session_path.write_text(
+                json.dumps(
+                    {
+                        "type": "user",
+                        "timestamp": "2026-05-02T10:00:00Z",
+                        "uuid": "u1",
+                        "message": {"role": "user", "content": "Start alias work"},
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            alias_path = container_sessions / "alias-session.jsonl"
+
+            engine = SyncEngine(self.db)
+            engine._source_identity_policy = SourceIdentityPolicy(
+                aliases=(
+                    SourceRootAlias(
+                        root_id=SourceRootId("session_mount"),
+                        alias_path=host_sessions,
+                    ),
+                    SourceRootAlias(
+                        root_id=SourceRootId("session_mount"),
+                        alias_path=container_sessions,
+                    ),
+                )
+            )
+
+            first = await engine._sync_single_session("project-1", session_path)
+            counts_after_first = await self._table_counts(
+                "sessions",
+                "session_messages",
+                "telemetry_events",
+                "session_usage_attributions",
+                "sync_state",
+            )
+            second = await engine._sync_single_session("project-1", alias_path, force=True)
+            counts_after_second = await self._table_counts(
+                "sessions",
+                "session_messages",
+                "telemetry_events",
+                "session_usage_attributions",
+                "sync_state",
+            )
+            source_files = await self._session_source_files()
+
+        self.assertTrue(first)
+        self.assertTrue(second)
+        self.assertEqual(counts_after_first, counts_after_second)
+        self.assertEqual(len(source_files), 1)
+        self.assertIn("ccdash-source:v1/project-1/session/session_mount/alias-session.jsonl", source_files)
+
+    async def _table_counts(self, *table_names: str) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for table_name in table_names:
+            async with self.db.execute(f"SELECT COUNT(*) AS count FROM {table_name}") as cur:
+                row = await cur.fetchone()
+                counts[table_name] = int(row["count"])
+        return counts
+
+    async def _session_source_files(self) -> set[str]:
+        async with self.db.execute("SELECT source_file FROM sessions") as cur:
+            rows = await cur.fetchall()
+        return {str(row["source_file"]) for row in rows}
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_source_alias_duplicate_audit.py
+++ b/backend/tests/test_source_alias_duplicate_audit.py
@@ -5,8 +5,14 @@ from pathlib import PurePosixPath
 
 from backend.scripts.source_alias_duplicate_audit import (
     AUDIT_QUERY_SPECS,
+    COLLAPSE_STRATEGY,
+    SessionSourceCandidate,
     SourceAuditRow,
+    SyncStateCandidate,
     build_duplicate_audit_report,
+    build_source_collapse_plans,
+    choose_session_source_survivor,
+    choose_sync_state_survivor,
     render_text_report,
     report_as_dict,
 )
@@ -114,6 +120,93 @@ class SourceAliasDuplicateAuditTests(unittest.TestCase):
         self.assertIn("session_usage_attributions", spec_names)
         for spec in AUDIT_QUERY_SPECS:
             self.assertIn("$1", spec.sql, spec.table_name)
+
+    def test_sync_state_survivor_prefers_newest_mtime_then_synced_evidence(self) -> None:
+        survivor = choose_sync_state_survivor(
+            [
+                SyncStateCandidate("/host/session.jsonl", "old", 10.0, "2026-05-04T10:00:00Z", 500),
+                SyncStateCandidate("/container/session.jsonl", "new", 20.0, "2026-05-04T09:00:00Z", 100),
+                SyncStateCandidate("/other/session.jsonl", "tie", 20.0, "2026-05-04T11:00:00Z", 10),
+            ]
+        )
+
+        self.assertIsNotNone(survivor)
+        self.assertEqual(survivor.source_path, "/other/session.jsonl")
+        self.assertEqual(survivor.file_hash, "tie")
+
+    def test_session_survivor_prefers_transcript_and_derived_evidence(self) -> None:
+        survivor = choose_session_source_survivor(
+            [
+                SessionSourceCandidate(
+                    "/host/session.jsonl",
+                    session_count=2,
+                    updated_at="2026-05-04T12:00:00Z",
+                    canonical_message_count=4,
+                    usage_event_count=5,
+                ),
+                SessionSourceCandidate(
+                    "/container/session.jsonl",
+                    session_count=1,
+                    updated_at="2026-05-04T09:00:00Z",
+                    canonical_message_count=12,
+                    telemetry_event_count=3,
+                ),
+            ]
+        )
+
+        self.assertIsNotNone(survivor)
+        self.assertEqual(survivor.source_path, "/container/session.jsonl")
+
+    def test_build_source_collapse_plans_requires_alias_groups_and_project_scope(self) -> None:
+        plans = build_source_collapse_plans(
+            project_id="project-1",
+            policy=_policy(),
+            sync_state_candidates=[
+                SyncStateCandidate(
+                    "/Users/miethe/.claude/projects/foo/session.jsonl",
+                    "host-hash",
+                    10.0,
+                    "2026-05-04T10:00:00Z",
+                    100,
+                ),
+                SyncStateCandidate(
+                    "/home/ccdash/.claude/projects/foo/session.jsonl",
+                    "container-hash",
+                    20.0,
+                    "2026-05-04T11:00:00Z",
+                    200,
+                ),
+            ],
+            session_candidates=[
+                SessionSourceCandidate(
+                    "/Users/miethe/.claude/projects/foo/session.jsonl",
+                    session_count=1,
+                    updated_at="2026-05-04T10:00:00Z",
+                    canonical_message_count=1,
+                ),
+                SessionSourceCandidate(
+                    "/home/ccdash/.claude/projects/foo/session.jsonl",
+                    session_count=1,
+                    updated_at="2026-05-04T11:00:00Z",
+                    canonical_message_count=2,
+                ),
+            ],
+        )
+
+        self.assertEqual(len(plans), 1)
+        plan = plans[0]
+        self.assertEqual(
+            plan.source_key,
+            "ccdash-source:v1/project-1/session/claude_home/projects/foo/session.jsonl",
+        )
+        self.assertEqual(plan.sync_state_survivor.source_path, "/home/ccdash/.claude/projects/foo/session.jsonl")
+        self.assertEqual(plan.session_survivor.source_path, "/home/ccdash/.claude/projects/foo/session.jsonl")
+        self.assertIn("update sessions.source_file", "\n".join(plan.actions))
+
+    def test_collapse_strategy_documents_dry_run_project_scope_and_rollback(self) -> None:
+        self.assertIn("explicit project id", COLLAPSE_STRATEGY)
+        self.assertIn("dry-run", COLLAPSE_STRATEGY)
+        self.assertIn("Rollback", COLLAPSE_STRATEGY)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_source_alias_duplicate_audit.py
+++ b/backend/tests/test_source_alias_duplicate_audit.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import PurePosixPath
+
+from backend.scripts.source_alias_duplicate_audit import (
+    AUDIT_QUERY_SPECS,
+    SourceAuditRow,
+    build_duplicate_audit_report,
+    render_text_report,
+    report_as_dict,
+)
+from backend.services.source_identity import SourceIdentityPolicy, SourceRootAlias, SourceRootId
+
+
+def _policy() -> SourceIdentityPolicy:
+    return SourceIdentityPolicy(
+        aliases=(
+            SourceRootAlias(
+                root_id=SourceRootId("claude_home"),
+                alias_path=PurePosixPath("/Users/miethe/.claude"),
+            ),
+            SourceRootAlias(
+                root_id=SourceRootId("claude_home"),
+                alias_path=PurePosixPath("/home/ccdash/.claude"),
+            ),
+        )
+    )
+
+
+class SourceAliasDuplicateAuditTests(unittest.TestCase):
+    def test_groups_host_container_aliases_by_canonical_source_key(self) -> None:
+        rows = [
+            SourceAuditRow("sync_state", "/Users/miethe/.claude/projects/foo/session.jsonl", 1),
+            SourceAuditRow("sync_state", "/home/ccdash/.claude/projects/foo/session.jsonl", 1),
+            SourceAuditRow("sessions", "/Users/miethe/.claude/projects/foo/session.jsonl", 2),
+            SourceAuditRow("sessions", "/home/ccdash/.claude/projects/foo/session.jsonl", 3),
+            SourceAuditRow("session_messages", "/home/ccdash/.claude/projects/foo/session.jsonl", 12),
+        ]
+
+        report = build_duplicate_audit_report(project_id="project-1", rows=rows, policy=_policy())
+
+        self.assertEqual(report.duplicate_group_count, 1)
+        group = report.duplicate_groups[0]
+        self.assertEqual(
+            group.source_key,
+            "ccdash-source:v1/project-1/session/claude_home/projects/foo/session.jsonl",
+        )
+        self.assertEqual(
+            group.source_paths,
+            [
+                "/Users/miethe/.claude/projects/foo/session.jsonl",
+                "/home/ccdash/.claude/projects/foo/session.jsonl",
+            ],
+        )
+        self.assertEqual(group.table_counts["sync_state"], 2)
+        self.assertEqual(group.table_counts["sessions"], 5)
+        self.assertEqual(group.table_counts["session_messages"], 12)
+
+    def test_unknown_singletons_do_not_report_as_alias_duplicates(self) -> None:
+        rows = [
+            SourceAuditRow("sync_state", "/tmp/one.jsonl", 1),
+            SourceAuditRow("sessions", "/tmp/two.jsonl", 1),
+        ]
+
+        report = build_duplicate_audit_report(project_id="project-1", rows=rows, policy=_policy())
+
+        self.assertEqual(report.duplicate_group_count, 0)
+        self.assertEqual(report.table_totals, {"sessions": 1, "sync_state": 1})
+
+    def test_alias_path_summaries_preserve_investigation_style_counts(self) -> None:
+        rows = [
+            SourceAuditRow("sessions", "/Users/miethe/.claude/projects/foo/a.jsonl", 1809),
+            SourceAuditRow("sessions", "/home/ccdash/.claude/projects/foo/a.jsonl", 4106),
+            SourceAuditRow("sync_state", "/Users/miethe/.claude/projects/foo/a.jsonl", 5603),
+            SourceAuditRow("sync_state", "/home/ccdash/.claude/projects/foo/a.jsonl", 4077),
+        ]
+
+        report = build_duplicate_audit_report(project_id="project-1", rows=rows, policy=_policy())
+        payload = report_as_dict(report)
+
+        summaries = {
+            (item["tableName"], item["aliasPath"]): item["rowCount"]
+            for item in payload["aliasPathSummaries"]
+        }
+        self.assertEqual(summaries[("sessions", "/Users/miethe/.claude")], 1809)
+        self.assertEqual(summaries[("sessions", "/home/ccdash/.claude")], 4106)
+        self.assertEqual(summaries[("sync_state", "/Users/miethe/.claude")], 5603)
+        self.assertEqual(summaries[("sync_state", "/home/ccdash/.claude")], 4077)
+
+    def test_text_report_lists_duplicates_without_failing_on_them(self) -> None:
+        report = build_duplicate_audit_report(
+            project_id="project-1",
+            rows=[
+                SourceAuditRow("sync_state", "/Users/miethe/.claude/projects/foo/session.jsonl", 1),
+                SourceAuditRow("sync_state", "/home/ccdash/.claude/projects/foo/session.jsonl", 1),
+            ],
+            policy=_policy(),
+        )
+
+        text = render_text_report(report)
+
+        self.assertIn("Duplicate source groups: 1", text)
+        self.assertIn("sourcePath=/Users/miethe/.claude/projects/foo/session.jsonl", text)
+        self.assertIn("sourcePath=/home/ccdash/.claude/projects/foo/session.jsonl", text)
+
+    def test_audit_queries_are_project_scoped(self) -> None:
+        spec_names = {spec.table_name for spec in AUDIT_QUERY_SPECS}
+
+        self.assertIn("sync_state", spec_names)
+        self.assertIn("sessions", spec_names)
+        self.assertIn("session_messages", spec_names)
+        self.assertIn("telemetry_events", spec_names)
+        self.assertIn("session_usage_attributions", spec_names)
+        for spec in AUDIT_QUERY_SPECS:
+            self.assertIn("$1", spec.sql, spec.table_name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_source_alias_duplicate_audit.py
+++ b/backend/tests/test_source_alias_duplicate_audit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import unittest
 from pathlib import PurePosixPath
 
@@ -9,10 +10,15 @@ from backend.scripts.source_alias_duplicate_audit import (
     SessionSourceCandidate,
     SourceAuditRow,
     SyncStateCandidate,
+    apply_source_collapse_plans,
     build_duplicate_audit_report,
     build_source_collapse_plans,
+    collapse_apply_result_as_dict,
+    collapse_plans_as_dict,
     choose_session_source_survivor,
     choose_sync_state_survivor,
+    render_collapse_apply_result,
+    render_collapse_plan_report,
     render_text_report,
     report_as_dict,
 )
@@ -32,6 +38,20 @@ def _policy() -> SourceIdentityPolicy:
             ),
         )
     )
+
+
+class _FakePostgresConnection:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[object, ...]]] = []
+
+    async def execute(self, sql: str, *args: object) -> str:
+        self.calls.append((sql, args))
+        command = sql.strip().split()[0].upper()
+        if command == "UPDATE":
+            return "UPDATE 2"
+        if command == "DELETE":
+            return "DELETE 2"
+        return "INSERT 0 1"
 
 
 class SourceAliasDuplicateAuditTests(unittest.TestCase):
@@ -207,6 +227,129 @@ class SourceAliasDuplicateAuditTests(unittest.TestCase):
         self.assertIn("explicit project id", COLLAPSE_STRATEGY)
         self.assertIn("dry-run", COLLAPSE_STRATEGY)
         self.assertIn("Rollback", COLLAPSE_STRATEGY)
+
+    def test_collapse_plan_rendering_includes_survivor_and_actions(self) -> None:
+        plans = build_source_collapse_plans(
+            project_id="project-1",
+            policy=_policy(),
+            sync_state_candidates=[
+                SyncStateCandidate(
+                    "/Users/miethe/.claude/projects/foo/session.jsonl",
+                    "host-hash",
+                    10.0,
+                    "2026-05-04T10:00:00Z",
+                    100,
+                ),
+                SyncStateCandidate(
+                    "/home/ccdash/.claude/projects/foo/session.jsonl",
+                    "container-hash",
+                    20.0,
+                    "2026-05-04T11:00:00Z",
+                    200,
+                ),
+            ],
+            session_candidates=[],
+        )
+
+        payload = collapse_plans_as_dict(plans)
+        text = render_collapse_plan_report(plans)
+
+        self.assertEqual(payload[0]["syncStateSurvivor"]["fileHash"], "container-hash")
+        self.assertIn("Source alias collapse dry run", text)
+        self.assertIn("syncStateSurvivor=/home/ccdash/.claude/projects/foo/session.jsonl", text)
+
+    def test_apply_source_collapse_plans_is_dry_run_by_default(self) -> None:
+        conn = _FakePostgresConnection()
+        plans = build_source_collapse_plans(
+            project_id="project-1",
+            policy=_policy(),
+            sync_state_candidates=[
+                SyncStateCandidate(
+                    "/Users/miethe/.claude/projects/foo/session.jsonl",
+                    "host-hash",
+                    10.0,
+                    "2026-05-04T10:00:00Z",
+                    100,
+                ),
+                SyncStateCandidate(
+                    "/home/ccdash/.claude/projects/foo/session.jsonl",
+                    "container-hash",
+                    20.0,
+                    "2026-05-04T11:00:00Z",
+                    200,
+                ),
+            ],
+            session_candidates=[
+                SessionSourceCandidate(
+                    "/home/ccdash/.claude/projects/foo/session.jsonl",
+                    session_count=3,
+                    updated_at="2026-05-04T11:00:00Z",
+                ),
+            ],
+        )
+
+        result = asyncio.run(
+            apply_source_collapse_plans(
+                conn,
+                project_id="project-1",
+                plans=plans,
+                apply=False,
+            )
+        )
+
+        self.assertFalse(result.applied)
+        self.assertEqual(result.planned_groups, 1)
+        self.assertEqual(result.sync_state_upserts, 1)
+        self.assertEqual(result.session_updates, 3)
+        self.assertEqual(conn.calls, [])
+
+    def test_apply_source_collapse_plans_updates_canonical_sources(self) -> None:
+        conn = _FakePostgresConnection()
+        plans = build_source_collapse_plans(
+            project_id="project-1",
+            policy=_policy(),
+            sync_state_candidates=[
+                SyncStateCandidate(
+                    "/Users/miethe/.claude/projects/foo/session.jsonl",
+                    "host-hash",
+                    10.0,
+                    "2026-05-04T10:00:00Z",
+                    100,
+                ),
+                SyncStateCandidate(
+                    "/home/ccdash/.claude/projects/foo/session.jsonl",
+                    "container-hash",
+                    20.0,
+                    "2026-05-04T11:00:00Z",
+                    200,
+                ),
+            ],
+            session_candidates=[],
+        )
+
+        result = asyncio.run(
+            apply_source_collapse_plans(
+                conn,
+                project_id="project-1",
+                plans=plans,
+                apply=True,
+            )
+        )
+
+        self.assertTrue(result.applied)
+        self.assertEqual(result.sync_state_upserts, 1)
+        self.assertEqual(result.sync_state_deletes, 2)
+        self.assertEqual(result.session_updates, 2)
+        self.assertEqual(result.relationship_updates, 2)
+        rendered = render_collapse_apply_result(result)
+        payload = collapse_apply_result_as_dict(result)
+        self.assertIn("Mode: applied", rendered)
+        self.assertEqual(payload["sessionUpdates"], 2)
+        self.assertEqual(len(conn.calls), 4)
+        self.assertEqual(
+            conn.calls[0][1][0],
+            "ccdash-source:v1/project-1/session/claude_home/projects/foo/session.jsonl",
+        )
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_source_identity.py
+++ b/backend/tests/test_source_identity.py
@@ -1,0 +1,140 @@
+from pathlib import PurePosixPath
+import unittest
+
+from backend.services.source_identity import (
+    ProjectId,
+    SourceIdentityInput,
+    SourceRootId,
+    resolve_source_identity,
+    source_identity_policy_from_env,
+)
+
+
+class SourceIdentityPolicyTests(unittest.TestCase):
+    def test_claude_host_and_container_paths_share_source_key(self) -> None:
+        policy = source_identity_policy_from_env(
+            {
+                "CCDASH_CLAUDE_HOME": "/Users/miethe/.claude",
+                "CCDASH_CLAUDE_CONTAINER_HOME": "/home/ccdash/.claude",
+            }
+        )
+
+        host = resolve_source_identity(
+            SourceIdentityInput(
+                project_id=ProjectId("skillmeat"),
+                artifact_kind="session",
+                observed_path=PurePosixPath(
+                    "/Users/miethe/.claude/projects/-Users-miethe-dev-homelab-development-skillmeat/session.jsonl"
+                ),
+            ),
+            policy,
+        )
+        container = resolve_source_identity(
+            SourceIdentityInput(
+                project_id=ProjectId("skillmeat"),
+                artifact_kind="session",
+                observed_path=PurePosixPath(
+                    "/home/ccdash/.claude/projects/-Users-miethe-dev-homelab-development-skillmeat/session.jsonl"
+                ),
+            ),
+            policy,
+        )
+
+        self.assertEqual(host.source_key, container.source_key)
+        self.assertEqual(host.root_id, SourceRootId("claude_home"))
+        self.assertEqual(host.relative_path, container.relative_path)
+
+    def test_codex_host_and_container_paths_share_source_key(self) -> None:
+        policy = source_identity_policy_from_env(
+            {
+                "CCDASH_CODEX_HOME": "/Users/miethe/.codex",
+                "CCDASH_CODEX_CONTAINER_HOME": "/home/ccdash/.codex",
+            }
+        )
+
+        host = resolve_source_identity(
+            SourceIdentityInput(
+                project_id=ProjectId("ccdash"),
+                artifact_kind="session",
+                observed_path=PurePosixPath("/Users/miethe/.codex/sessions/2026/05/session.jsonl"),
+            ),
+            policy,
+        )
+        container = resolve_source_identity(
+            SourceIdentityInput(
+                project_id=ProjectId("ccdash"),
+                artifact_kind="session",
+                observed_path=PurePosixPath("/home/ccdash/.codex/sessions/2026/05/session.jsonl"),
+            ),
+            policy,
+        )
+
+        self.assertEqual(host.source_key, container.source_key)
+        self.assertEqual(host.root_id, SourceRootId("codex_home"))
+
+    def test_workspace_host_and_container_paths_share_source_key(self) -> None:
+        policy = source_identity_policy_from_env(
+            {
+                "CCDASH_WORKSPACE_HOST_ROOT": "/Users/miethe/dev/homelab/development",
+                "CCDASH_WORKSPACE_CONTAINER_ROOT": "/workspace",
+            }
+        )
+
+        host = resolve_source_identity(
+            SourceIdentityInput(
+                project_id=ProjectId("ccdash"),
+                artifact_kind="document",
+                observed_path=PurePosixPath(
+                    "/Users/miethe/dev/homelab/development/CCDash/docs/project_plans/plan.md"
+                ),
+            ),
+            policy,
+        )
+        container = resolve_source_identity(
+            SourceIdentityInput(
+                project_id=ProjectId("ccdash"),
+                artifact_kind="document",
+                observed_path=PurePosixPath("/workspace/CCDash/docs/project_plans/plan.md"),
+            ),
+            policy,
+        )
+
+        self.assertEqual(host.source_key, container.source_key)
+        self.assertEqual(host.root_id, SourceRootId("workspace"))
+
+    def test_unknown_paths_are_stable_but_project_scoped(self) -> None:
+        policy = source_identity_policy_from_env({})
+        observed_path = PurePosixPath("/var/tmp/session.jsonl")
+
+        first = resolve_source_identity(
+            SourceIdentityInput(
+                project_id=ProjectId("project-a"),
+                artifact_kind="session",
+                observed_path=observed_path,
+            ),
+            policy,
+        )
+        second = resolve_source_identity(
+            SourceIdentityInput(
+                project_id=ProjectId("project-a"),
+                artifact_kind="session",
+                observed_path=observed_path,
+            ),
+            policy,
+        )
+        other_project = resolve_source_identity(
+            SourceIdentityInput(
+                project_id=ProjectId("project-b"),
+                artifact_kind="session",
+                observed_path=observed_path,
+            ),
+            policy,
+        )
+
+        self.assertEqual(first.source_key, second.source_key)
+        self.assertNotEqual(first.source_key, other_project.source_key)
+        self.assertEqual(first.root_id, SourceRootId("opaque"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_source_identity.py
+++ b/backend/tests/test_source_identity.py
@@ -3,7 +3,10 @@ import unittest
 
 from backend.services.source_identity import (
     ProjectId,
+    SourceAliasBehavior,
     SourceIdentityInput,
+    SourceIdentityPolicy,
+    SourceRootAlias,
     SourceRootId,
     resolve_source_identity,
     source_identity_policy_from_env,
@@ -134,6 +137,137 @@ class SourceIdentityPolicyTests(unittest.TestCase):
         self.assertEqual(first.source_key, second.source_key)
         self.assertNotEqual(first.source_key, other_project.source_key)
         self.assertEqual(first.root_id, SourceRootId("opaque"))
+
+    def test_optional_mount_host_and_container_paths_share_source_key(self) -> None:
+        policy = source_identity_policy_from_env(
+            {
+                "CCDASH_EXTRA_MOUNT_1_HOST": "/Volumes/agent-sessions",
+                "CCDASH_EXTRA_MOUNT_1_CONTAINER": "/mnt/ccdash/optional-1",
+            }
+        )
+
+        host = resolve_source_identity(
+            SourceIdentityInput(
+                project_id=ProjectId("project-a"),
+                artifact_kind="session",
+                observed_path=PurePosixPath("/Volumes/agent-sessions/customer-a/session.jsonl"),
+            ),
+            policy,
+        )
+        container = resolve_source_identity(
+            SourceIdentityInput(
+                project_id=ProjectId("project-a"),
+                artifact_kind="session",
+                observed_path=PurePosixPath("/mnt/ccdash/optional-1/customer-a/session.jsonl"),
+            ),
+            policy,
+        )
+
+        self.assertEqual(host.source_key, container.source_key)
+        self.assertEqual(host.root_id, SourceRootId("extra_mount_1"))
+
+    def test_longest_prefix_wins_for_nested_aliases(self) -> None:
+        policy = SourceIdentityPolicy(
+            aliases=(
+                SourceRootAlias(
+                    root_id=SourceRootId("workspace"),
+                    alias_path=PurePosixPath("/workspace"),
+                ),
+                SourceRootAlias(
+                    root_id=SourceRootId("claude_home"),
+                    alias_path=PurePosixPath("/workspace/.claude"),
+                ),
+            )
+        )
+
+        identity = resolve_source_identity(
+            SourceIdentityInput(
+                project_id=ProjectId("project-a"),
+                artifact_kind="session",
+                observed_path=PurePosixPath("/workspace/.claude/projects/project-a/session.jsonl"),
+            ),
+            policy,
+        )
+
+        self.assertEqual(identity.root_id, SourceRootId("claude_home"))
+        self.assertEqual(identity.relative_path, PurePosixPath("projects/project-a/session.jsonl"))
+
+    def test_dotdot_segments_are_normalized_without_filesystem_io(self) -> None:
+        policy = source_identity_policy_from_env(
+            {
+                "CCDASH_WORKSPACE_HOST_ROOT": "/Users/miethe/dev/homelab/development",
+                "CCDASH_WORKSPACE_CONTAINER_ROOT": "/workspace",
+            }
+        )
+
+        normalized = resolve_source_identity(
+            SourceIdentityInput(
+                project_id=ProjectId("ccdash"),
+                artifact_kind="document",
+                observed_path=PurePosixPath("/workspace/CCDash/docs/../docs/project_plans/plan.md"),
+            ),
+            policy,
+        )
+        direct = resolve_source_identity(
+            SourceIdentityInput(
+                project_id=ProjectId("ccdash"),
+                artifact_kind="document",
+                observed_path=PurePosixPath("/workspace/CCDash/docs/project_plans/plan.md"),
+            ),
+            policy,
+        )
+
+        self.assertEqual(normalized.source_key, direct.source_key)
+
+    def test_known_aliases_remain_project_scoped(self) -> None:
+        policy = source_identity_policy_from_env(
+            {
+                "CCDASH_CLAUDE_HOME": "/Users/miethe/.claude",
+                "CCDASH_CLAUDE_CONTAINER_HOME": "/home/ccdash/.claude",
+            }
+        )
+        observed_path = PurePosixPath("/Users/miethe/.claude/projects/shared/session.jsonl")
+
+        first = resolve_source_identity(
+            SourceIdentityInput(
+                project_id=ProjectId("project-a"),
+                artifact_kind="session",
+                observed_path=observed_path,
+            ),
+            policy,
+        )
+        second = resolve_source_identity(
+            SourceIdentityInput(
+                project_id=ProjectId("project-b"),
+                artifact_kind="session",
+                observed_path=observed_path,
+            ),
+            policy,
+        )
+
+        self.assertNotEqual(first.source_key, second.source_key)
+        self.assertEqual(first.relative_path, second.relative_path)
+
+    def test_reject_unknown_policy_rejects_paths_outside_known_roots(self) -> None:
+        policy = SourceIdentityPolicy(
+            aliases=(
+                SourceRootAlias(
+                    root_id=SourceRootId("workspace"),
+                    alias_path=PurePosixPath("/workspace"),
+                ),
+            ),
+            unknown_path_behavior=SourceAliasBehavior.REJECT_ESCAPE,
+        )
+
+        with self.assertRaises(ValueError):
+            resolve_source_identity(
+                SourceIdentityInput(
+                    project_id=ProjectId("project-a"),
+                    artifact_kind="session",
+                    observed_path=PurePosixPath("/var/tmp/session.jsonl"),
+                ),
+                policy,
+            )
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_sync_engine_linking.py
+++ b/backend/tests/test_sync_engine_linking.py
@@ -275,12 +275,18 @@ class SyncEngineSessionBackfillTests(unittest.IsolatedAsyncioTestCase):
             )
             sync_key = engine._canonical_source_key("project-1", path, "session")
 
-            with patch("backend.db.sync_engine.parse_session_file") as parse_mock:
+            with (
+                patch("backend.db.sync_engine.parse_session_file") as parse_mock,
+                patch("backend.db.sync_engine._publish_session_transcript_appends") as append_publish_mock,
+                patch("backend.db.sync_engine.publish_session_snapshot") as snapshot_publish_mock,
+            ):
                 synced = await SyncEngine._sync_single_session(engine, "project-1", path, force=False)
 
             self.assertFalse(synced)
             engine.sync_repo.get_sync_state.assert_awaited_once_with(sync_key)
             parse_mock.assert_not_called()
+            append_publish_mock.assert_not_called()
+            snapshot_publish_mock.assert_not_called()
             engine.session_repo.delete_by_source.assert_not_awaited()
             engine.sync_repo.upsert_sync_state.assert_not_awaited()
 

--- a/backend/tests/test_sync_engine_linking.py
+++ b/backend/tests/test_sync_engine_linking.py
@@ -10,6 +10,7 @@ from backend.db.sync_engine import (
     _select_linking_commands,
     _select_preferred_command_event,
 )
+from backend.services.source_identity import SourceIdentityPolicy, SourceRootAlias, SourceRootId
 
 
 class SyncEngineLinkingTests(unittest.TestCase):
@@ -229,15 +230,26 @@ class SyncEngineSessionBackfillTests(unittest.IsolatedAsyncioTestCase):
             engine.session_repo.list_by_source = AsyncMock(return_value=[{"id": "S-1", "thread_kind": "", "conversation_family_id": ""}])
             engine.session_repo.delete_by_source = AsyncMock()
             engine.session_repo.delete_relationships_for_source = AsyncMock()
+            engine._source_identity_policy = SourceIdentityPolicy(
+                aliases=(
+                    SourceRootAlias(
+                        root_id=SourceRootId("sessions_root"),
+                        alias_path=path.parent,
+                    ),
+                )
+            )
+            sync_key = engine._canonical_source_key("project-1", path, "session")
 
             with patch("backend.db.sync_engine.parse_session_file", return_value=None) as parse_mock, patch("backend.db.sync_engine.observability.start_span", return_value=nullcontext()), patch("backend.db.sync_engine.observability.record_ingestion"):
                 synced = await SyncEngine._sync_single_session(engine, "project-1", path, force=False)
 
             self.assertTrue(synced)
+            engine.sync_repo.get_sync_state.assert_awaited_once_with(sync_key)
             parse_mock.assert_called_once_with(path)
             engine.session_repo.delete_by_source.assert_awaited_once()
             engine.session_repo.delete_relationships_for_source.assert_awaited_once_with("project-1", str(path))
             engine.sync_repo.upsert_sync_state.assert_awaited_once()
+            self.assertEqual(engine.sync_repo.upsert_sync_state.await_args.args[0]["file_path"], sync_key)
 
     async def test_sync_single_session_skips_unchanged_file_when_lineage_present(self) -> None:
         with TemporaryDirectory() as tmpdir:
@@ -253,11 +265,21 @@ class SyncEngineSessionBackfillTests(unittest.IsolatedAsyncioTestCase):
             engine.session_repo.list_by_source = AsyncMock(return_value=[{"id": "S-1", "thread_kind": "root", "conversation_family_id": "S-1"}])
             engine.session_repo.delete_by_source = AsyncMock()
             engine.session_repo.delete_relationships_for_source = AsyncMock()
+            engine._source_identity_policy = SourceIdentityPolicy(
+                aliases=(
+                    SourceRootAlias(
+                        root_id=SourceRootId("sessions_root"),
+                        alias_path=path.parent,
+                    ),
+                )
+            )
+            sync_key = engine._canonical_source_key("project-1", path, "session")
 
             with patch("backend.db.sync_engine.parse_session_file") as parse_mock:
                 synced = await SyncEngine._sync_single_session(engine, "project-1", path, force=False)
 
             self.assertFalse(synced)
+            engine.sync_repo.get_sync_state.assert_awaited_once_with(sync_key)
             parse_mock.assert_not_called()
             engine.session_repo.delete_by_source.assert_not_awaited()
             engine.sync_repo.upsert_sync_state.assert_not_awaited()

--- a/backend/tests/test_sync_engine_linking.py
+++ b/backend/tests/test_sync_engine_linking.py
@@ -246,8 +246,8 @@ class SyncEngineSessionBackfillTests(unittest.IsolatedAsyncioTestCase):
             self.assertTrue(synced)
             engine.sync_repo.get_sync_state.assert_awaited_once_with(sync_key)
             parse_mock.assert_called_once_with(path)
-            engine.session_repo.delete_by_source.assert_awaited_once()
-            engine.session_repo.delete_relationships_for_source.assert_awaited_once_with("project-1", str(path))
+            engine.session_repo.delete_by_source.assert_awaited_once_with(sync_key)
+            engine.session_repo.delete_relationships_for_source.assert_awaited_once_with("project-1", sync_key)
             engine.sync_repo.upsert_sync_state.assert_awaited_once()
             self.assertEqual(engine.sync_repo.upsert_sync_state.await_args.args[0]["file_path"], sync_key)
 

--- a/deploy/runtime/README.md
+++ b/deploy/runtime/README.md
@@ -69,6 +69,27 @@ Required read-only ingest mounts:
 | Claude home | `CCDASH_CLAUDE_HOME=~/.claude` | `CCDASH_CLAUDE_CONTAINER_HOME=/home/ccdash/.claude` | Provides Claude Code project/session metadata for watcher ingest. |
 | Codex home | `CCDASH_CODEX_HOME=~/.codex` | `CCDASH_CODEX_CONTAINER_HOME=/home/ccdash/.codex` | Provides Codex session metadata for watcher ingest. |
 
+### Watch Scope And Startup Cost
+
+`worker-watch` resolves its watch scope from the selected project entry. Existing `sessionsPath` / `pathConfig.sessions`, plan-docs, progress, enabled test-result sources, and any filesystem paths made visible by the workspace, `.claude`, `.codex`, or optional mounts can become part of the startup sync and live-watch corpus.
+
+The biggest cost driver is usually the session tree:
+
+- `sessionsPath` is the direct session-corpus pointer. A project-specific directory keeps startup reconciliation bounded. A broad path such as all of `~/.codex/sessions` or all of `~/.claude/projects` asks the watcher to discover and reconcile every visible JSONL transcript under that root.
+- `.claude` mounts are required when project entries point at Claude Code session data, usually under `~/.claude/projects/...`. Mount the home only when those paths are intentional, and prefer a project-specific `sessionsPath` when possible.
+- `.codex` mounts are required when project entries point at Codex session data, commonly under `~/.codex/sessions/...`. Global Codex session roots can include old and unrelated conversations, so they should not be treated as a cheap default.
+- Workspace roots make project docs, progress files, and repository-relative session paths visible. Set `CCDASH_WORKSPACE_HOST_ROOT` to the smallest stable root that still contains the projects referenced by `projects.json`; mounting an entire development tree can add unrelated repositories and high-churn files to startup scans.
+- Optional mounts add additional readable roots for projects that live outside the shared workspace or agent homes. Unused optional slots point at empty directories and have negligible cost. When a slot is used, avoid broad cache, build-output, or archive roots unless the project registry explicitly needs them.
+
+`watchPathCount` in `/detailz` counts resolved top-level watch roots, not the number of files below them. A small `watchPathCount` can still represent thousands of JSONL files and a large startup write workload. Broad global session roots should be an intentional operator choice, especially before enabling startup sync against long-lived `.claude` or `.codex` homes.
+
+Estimate session scope before restarting a watcher:
+
+```bash
+find "${CCDASH_CLAUDE_HOME:-$HOME/.claude}/projects" -name '*.jsonl' -type f 2>/dev/null | wc -l
+find "${CCDASH_CODEX_HOME:-$HOME/.codex}/sessions" -name '*.jsonl' -type f 2>/dev/null | wc -l
+```
+
 ### Env-Driven Optional Mounts
 
 `compose.yaml` also exposes six optional read-only bind-mount slots:

--- a/deploy/runtime/README.md
+++ b/deploy/runtime/README.md
@@ -154,8 +154,16 @@ $COMPOSE up --build -d
 
 Expected probes:
 
+Before using the API host port, confirm `127.0.0.1:8000` belongs to this stack. Another dev server can occupy that address and make host-port probes misleading:
+
 ```bash
-curl -fsS http://localhost:8000/api/health/ready | python3 -m json.tool
+lsof -nP -iTCP:8000 -sTCP:LISTEN
+```
+
+When `8000` is already bound by another process, validate the stack through the frontend proxy at `127.0.0.1:3131` or from inside the Compose network against the API service name.
+
+```bash
+curl -fsS http://127.0.0.1:3131/api/health/ready | python3 -m json.tool
 curl -fsS http://localhost:9465/readyz | python3 -m json.tool
 curl -fsS http://localhost:9466/readyz | python3 -m json.tool
 
@@ -163,7 +171,7 @@ curl -fsS http://localhost:9465/detailz | python3 -c 'import json,sys; p=json.lo
 
 curl -fsS http://localhost:9466/detailz | python3 -c 'import json,sys; p=json.load(sys.stdin); d=p.get("detail",{}); w=d.get("watcher",{}); wp=d.get("worker",{}); print(json.dumps({"runtimeProfile":p.get("runtimeProfile"), "ready":p.get("ready",{}).get("status"), "watcherState":w.get("state"), "watchPathCount":w.get("watchPathCount"), "lastChangeSyncAt":w.get("lastChangeSyncAt"), "lastChangeCount":w.get("lastChangeCount"), "lastSyncStatus":w.get("lastSyncStatus"), "workerWatcherDisabled":wp.get("watcherDisabled"), "syncLagSeconds":wp.get("syncLagSeconds"), "backpressure":wp.get("backpressure")}, indent=2))'
 
-curl -fsS http://localhost:8000/api/health/detail | python3 -c 'import json,sys; p=json.load(sys.stdin); f=p.get("detail",{}).get("liveFanout",{}); print(json.dumps({"mode":f.get("mode"), "running":f.get("running"), "connected":f.get("connected"), "errorCount":f.get("errorCount"), "listener":f.get("listener"), "recentErrors":f.get("recentErrors")}, indent=2))'
+curl -fsS http://127.0.0.1:3131/api/health/detail | python3 -c 'import json,sys; p=json.load(sys.stdin); f=p.get("detail",{}).get("liveFanout",{}); print(json.dumps({"mode":f.get("mode"), "running":f.get("running"), "connected":f.get("connected"), "errorCount":f.get("errorCount"), "listener":f.get("listener"), "recentErrors":f.get("recentErrors")}, indent=2))'
 ```
 
 Expected values:
@@ -269,6 +277,7 @@ Common hosted-smoke failures and what they mean:
 | --- | --- | --- |
 | `worker` exits during startup | `CCDASH_WORKER_PROJECT_ID` is unset or unresolved | choose a real project id and rerun |
 | API readiness fails | migrations or DB connectivity failed | inspect `docker compose logs api postgres` and correct the Postgres config before retrying |
+| `127.0.0.1:8000` responds but stack validation looks wrong | another local dev server is bound to the API host port | run `lsof -nP -iTCP:8000 -sTCP:LISTEN`; use `127.0.0.1:3131/api/health/ready` or a container-internal API probe for this stack |
 | worker readiness fails | worker binding, startup sync, or probe binding failed | inspect `docker compose logs worker`; confirm `CCDASH_WORKER_PROBE_*` and project binding |
 | telemetry exporter checks fail in an enterprise stack | telemetry exporter env is incomplete or disabled | set `CCDASH_TELEMETRY_EXPORT_ENABLED=true`, `CCDASH_SAM_ENDPOINT`, and `CCDASH_SAM_API_KEY` |
 | telemetry exporter checks return a retry or abandoned error with non-zero batch size | the stack has real queued telemetry rows but the sink is not valid | point the exporter at a real sink or clear the queue before rerunning |

--- a/deploy/runtime/README.md
+++ b/deploy/runtime/README.md
@@ -111,7 +111,35 @@ The repo includes `deploy/runtime/watchers/ccdash.env.example` as a concrete exa
 
 For multi-project deployments, prefer mounting a stable superset root shared by all watcher containers, then vary only `CCDASH_WORKER_WATCH_PROJECT_ID` and `CCDASH_WORKER_WATCH_PROBE_PORT` per watcher. When projects live on unrelated host roots, use the optional mount slots in each watcher's env overlay. Do not use Compose `--scale worker-watch=N` for v1: each watcher needs a distinct project id and probe port, which requires distinct service/env configuration.
 
-On macOS Docker Desktop, bind-mounted filesystem events can be unreliable. If `worker-watch` starts but does not see new JSONL changes, set `WATCHFILES_FORCE_POLLING=true` in `deploy/runtime/.env` and restart it. The shipped compose file passes this variable only to `worker-watch`; keep polling scoped there because it is a compatibility mode for Docker Desktop file sharing, not the default Linux path.
+On macOS Docker Desktop, bind-mounted filesystem events can be unreliable. If `worker-watch` starts but does not see new JSONL changes, set `WATCHFILES_FORCE_POLLING=true` in `deploy/runtime/.env` and restart it. The shipped compose file passes this variable only to `worker-watch`; keep polling scoped there because it is a compatibility mode for Docker Desktop file sharing, not the default Linux path. Do not copy `WATCHFILES_FORCE_POLLING` into shared backend, API, or default worker environment blocks.
+
+### Startup Sync And Polling Load
+
+`worker-watch` has two different load profiles:
+
+- Startup sync load happens when `CCDASH_WORKER_WATCH_STARTUP_SYNC_ENABLED=true` and the worker is reconciling the mounted corpus before it settles into live watching. High worker CPU, Postgres CPU, and Postgres I/O can be expected during this window, especially for broad `.claude`, `.codex`, or workspace mounts with thousands of JSONL files.
+- Idle polling load is sustained `worker-watch` CPU after startup sync is complete and no watched files are changing. With `WATCHFILES_FORCE_POLLING=false`, idle CPU should settle low outside event bursts. With `WATCHFILES_FORCE_POLLING=true`, idle CPU can remain higher because the watcher periodically scans bind mounts; disable it again after Docker Desktop event delivery is confirmed.
+
+Use these commands to separate startup sync from idle polling:
+
+```bash
+COMPOSE="docker compose --env-file deploy/runtime/.env -f deploy/runtime/compose.yaml --profile enterprise --profile postgres --profile live-watch"
+
+$COMPOSE ps
+
+curl -fsS http://localhost:9466/detailz | python3 -c 'import json,sys; p=json.load(sys.stdin); d=p.get("detail",{}); w=d.get("watcher",{}); worker=d.get("worker",{}); print(json.dumps({"runtimeProfile":p.get("runtimeProfile"), "ready":p.get("ready",{}).get("status"), "startupSync":worker.get("jobs",{}).get("startupSync"), "watcherState":w.get("state"), "watchPathCount":w.get("watchPathCount"), "lastChangeSyncAt":w.get("lastChangeSyncAt"), "lastSyncStatus":w.get("lastSyncStatus"), "backpressure":worker.get("backpressure")}, indent=2))'
+
+$COMPOSE stats --no-stream worker-watch postgres
+
+$COMPOSE exec -T postgres psql -U ccdash -d ccdash \
+  -c "select relname, n_live_tup, n_dead_tup, n_tup_ins, n_tup_del from pg_stat_user_tables where relname in ('sessions','session_messages','telemetry_events','session_usage_attributions','sync_state') order by relname;"
+```
+
+Interpretation:
+
+- If `startupSync` is `running` or reports backlog, CPU and write I/O are startup reconciliation load. Wait for the startup job to finish before judging idle watcher cost.
+- If startup sync is complete, no files are changing, and `worker-watch` CPU remains high across repeated `stats --no-stream` samples, treat it as idle polling or watch-scope load. First confirm whether `WATCHFILES_FORCE_POLLING=true`; then reduce watch scope or disable polling after event delivery works.
+- If table counters grow on an unchanged second startup, that indicates re-ingest/write amplification and should be investigated separately from polling CPU.
 
 ## Enterprise Live Ingest Smoke
 

--- a/docs/project_plans/implementation_plans/infrastructure/live-ingest-source-path-canonicalization-hardening-v1.md
+++ b/docs/project_plans/implementation_plans/infrastructure/live-ingest-source-path-canonicalization-hardening-v1.md
@@ -49,6 +49,7 @@ commit_refs: []
 pr_refs: []
 files_affected:
   - backend/services/source_identity.py
+  - backend/tests/test_source_identity.py
   - .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-1-progress.md
   - .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-2-progress.md
   - docs/project_plans/implementation_plans/infrastructure/live-ingest-source-path-canonicalization-hardening-v1.md

--- a/docs/project_plans/implementation_plans/infrastructure/live-ingest-source-path-canonicalization-hardening-v1.md
+++ b/docs/project_plans/implementation_plans/infrastructure/live-ingest-source-path-canonicalization-hardening-v1.md
@@ -50,6 +50,7 @@ pr_refs: []
 files_affected:
   - backend/db/sync_engine.py
   - backend/services/source_identity.py
+  - backend/tests/test_file_watcher.py
   - backend/tests/test_sync_engine_linking.py
   - backend/tests/test_source_identity.py
   - .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-1-progress.md

--- a/docs/project_plans/implementation_plans/infrastructure/live-ingest-source-path-canonicalization-hardening-v1.md
+++ b/docs/project_plans/implementation_plans/infrastructure/live-ingest-source-path-canonicalization-hardening-v1.md
@@ -45,7 +45,14 @@ related_documents:
   - backend/db/repositories/postgres/runtime_state.py
   - backend/db/repositories/postgres/sessions.py
   - backend/db/repositories/postgres/session_messages.py
-commit_refs: []
+commit_refs:
+  - 60d5b4a
+  - 79ad357
+  - 462019e
+  - 9196922
+  - 7e57c7f
+  - 0577e4c
+  - f0c106a
 pr_refs: []
 files_affected:
   - backend/db/sync_engine.py

--- a/docs/project_plans/implementation_plans/infrastructure/live-ingest-source-path-canonicalization-hardening-v1.md
+++ b/docs/project_plans/implementation_plans/infrastructure/live-ingest-source-path-canonicalization-hardening-v1.md
@@ -48,7 +48,9 @@ related_documents:
 commit_refs: []
 pr_refs: []
 files_affected:
+  - backend/db/sync_engine.py
   - backend/services/source_identity.py
+  - backend/tests/test_sync_engine_linking.py
   - backend/tests/test_source_identity.py
   - .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-1-progress.md
   - .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-2-progress.md

--- a/docs/project_plans/implementation_plans/infrastructure/live-ingest-source-path-canonicalization-hardening-v1.md
+++ b/docs/project_plans/implementation_plans/infrastructure/live-ingest-source-path-canonicalization-hardening-v1.md
@@ -3,7 +3,7 @@ schema_name: ccdash_document
 schema_version: 3
 doc_type: implementation_plan
 doc_subtype: hardening_plan
-status: draft
+status: in-progress
 category: infrastructure
 title: Live Ingest Source Path Canonicalization Hardening V1 - Implementation Plan
 description: Hardening plan to stop worker-watch container path drift from causing duplicate session ingestion and excessive Postgres startup churn.
@@ -62,6 +62,9 @@ files_affected:
   - backend/tests/test_source_identity.py
   - .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-1-progress.md
   - .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-2-progress.md
+  - .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-3-progress.md
+  - .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-4-progress.md
+  - .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-5-progress.md
   - docs/project_plans/implementation_plans/infrastructure/live-ingest-source-path-canonicalization-hardening-v1.md
 ---
 

--- a/docs/project_plans/implementation_plans/infrastructure/live-ingest-source-path-canonicalization-hardening-v1.md
+++ b/docs/project_plans/implementation_plans/infrastructure/live-ingest-source-path-canonicalization-hardening-v1.md
@@ -1,0 +1,263 @@
+---
+schema_name: ccdash_document
+schema_version: 3
+doc_type: implementation_plan
+doc_subtype: hardening_plan
+status: draft
+category: infrastructure
+title: Live Ingest Source Path Canonicalization Hardening V1 - Implementation Plan
+description: Hardening plan to stop worker-watch container path drift from causing duplicate session ingestion and excessive Postgres startup churn.
+summary: Canonicalize filesystem-derived session source identity across host and container runtimes, migrate duplicate sync state safely, and add operator validation for startup CPU, memory, and Postgres write amplification.
+author: codex
+created: 2026-05-04
+updated: 2026-05-04
+audience:
+  - ai-agents
+  - developers
+  - backend-platform
+  - devops
+tags:
+  - implementation
+  - hardening
+  - performance
+  - live-ingest
+  - worker-watch
+  - postgres
+  - source-paths
+feature_slug: live-ingest-source-path-canonicalization-hardening
+feature_version: v1
+priority: high
+risk_level: high
+effort_estimate: 24 story points
+prd_ref: null
+plan_ref: null
+related:
+  - docs/project_plans/implementation_plans/enhancements/enterprise-live-session-ingest-v1.md
+  - docs/project_plans/implementation_plans/infrastructure/runtime-performance-hardening-v1.md
+  - docs/project_plans/PRDs/enhancements/enterprise-live-session-ingest-v1.md
+  - docs/project_plans/PRDs/infrastructure/runtime-performance-hardening-v1.md
+related_documents:
+  - deploy/runtime/README.md
+  - deploy/runtime/compose.yaml
+  - projects.json
+  - backend/db/sync_engine.py
+  - backend/db/file_watcher.py
+  - backend/db/repositories/postgres/runtime_state.py
+  - backend/db/repositories/postgres/sessions.py
+  - backend/db/repositories/postgres/session_messages.py
+commit_refs: []
+pr_refs: []
+files_affected:
+  - backend/services/source_identity.py
+  - .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-1-progress.md
+  - .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-2-progress.md
+  - docs/project_plans/implementation_plans/infrastructure/live-ingest-source-path-canonicalization-hardening-v1.md
+---
+
+# Implementation Plan: Live Ingest Source Path Canonicalization Hardening V1
+
+Plan ID: `IMPL-2026-05-04-LIVE-INGEST-SOURCE-PATH-CANONICALIZATION`
+
+Complexity: Medium-high
+
+Total estimated effort: 24 story points
+
+Target timeline: 1 week
+
+## Executive Summary
+
+Live `worker-watch` validation on 2026-05-04 showed high CPU and Postgres churn during startup ingestion. The primary issue was not a confirmed memory leak. It was path identity drift: the same SkillMeat session corpus existed in Postgres under host paths and container paths. Host sync had stored entries such as `/Users/miethe/.claude/projects/...`, while `worker-watch` inside the container saw the same corpus at `/home/ccdash/.claude/projects/...`. Because `sync_state.file_path` and `sessions.source_file` are path-keyed, the container startup sync treated already-ingested files as new work.
+
+This plan hardens filesystem-derived source identity so host and container runtimes converge on a stable canonical source key. It also adds a migration/backfill path for duplicate historical rows, operator guardrails around polling mode, and a repeatable docker-compose validation script for CPU, memory, and Postgres write amplification.
+
+## Live Evidence
+
+Observed while the stack was running through `docker-compose` with `deploy/runtime/.env`:
+
+| Signal | Evidence | Interpretation |
+| --- | --- | --- |
+| Watcher startup remained active | `worker-watch /detailz` reported `startupSync=running`, backlog `startupSync=1` | Startup sync was still reconciling, not idle watching. |
+| Worker CPU was high | `worker-watch` ranged from 27-97% CPU; Python process reported up to 75% in `docker-compose top` | Expected while parsing and persisting thousands of sessions. |
+| Postgres CPU and I/O were high | Postgres ranged from 52-142% CPU; block I/O grew past 2 GiB read and 2 GiB written | Startup sync shifted into DB write/index/WAL work. |
+| Memory did not show leak shape | `worker-watch` moved from 155 MiB to 415 MiB; Postgres peaked near 884 MiB then dropped near 268 MiB | Heavy working set and cache behavior, not enough evidence for monotonic leakage. |
+| Duplicate source identity exists | `sessions`: 4106 container-path SkillMeat rows and 1809 host-path SkillMeat rows; `sync_state`: 4077 container-path entries and 5603 host-path entries | Same corpus is represented under multiple path identities. |
+| Watched corpus is large | SkillMeat Claude sessions: 5607 `.jsonl` files, 1.2 GiB; total watched artifact candidates: 9877 files | Polling and startup scans are expensive even after canonicalization. |
+| Direct host port was misleading | `127.0.0.1:8000` was also bound by a BoxBrain uvicorn process; `127.0.0.1:3131/api/health/ready` returned in ~27 ms | Validate API through the frontend proxy or container-internal address when port conflicts exist. |
+
+## Goals
+
+1. Stop host/container path drift from causing duplicate `sync_state`, `sessions`, `session_messages`, `telemetry_events`, and attribution churn.
+2. Preserve stable read behavior for existing UI/API consumers while source identity is normalized.
+3. Make startup sync idempotent across local host runs and container `worker-watch` runs.
+4. Provide a migration/backfill strategy for existing duplicate rows.
+5. Add focused validation that distinguishes expected startup load from sustained idle CPU or memory growth.
+
+## Non-Goals
+
+1. Do not redesign the entire session ingestion pipeline.
+2. Do not replace Postgres canonical transcript storage or change user-facing session DTOs.
+3. Do not remove `worker-watch`; this plan hardens its source identity and operator posture.
+4. Do not make polling mode the default. `WATCHFILES_FORCE_POLLING=true` remains a compatibility fallback for macOS file-sharing gaps.
+
+## Implementation Strategy
+
+Architecture sequence:
+
+1. Define a runtime-independent canonical source identity contract.
+2. Apply canonical source keys at sync-state lookup, session persistence, and delete/replace boundaries.
+3. Add migration tooling to collapse duplicate host/container rows safely.
+4. Harden watcher/operator configuration to reduce accidental polling and broad startup work.
+5. Validate with docker-compose startup and idle profiles.
+
+Critical path:
+
+1. Canonical source identity helper lands with tests.
+2. Sync engine and repositories use canonical source keys before writes.
+3. Duplicate cleanup tool proves no rows are lost.
+4. docker-compose validation shows second startup skips already-ingested sources.
+
+Parallel work:
+
+1. Operator docs and smoke script can proceed once the canonical identity contract is drafted.
+2. Postgres duplicate-audit queries can be built in parallel with backend helper tests.
+3. Polling-mode docs can be updated independently from migration tooling.
+
+## Phase Overview
+
+| Phase | Title | Estimate | Primary Subagents | Outcome |
+| --- | --- | ---: | --- | --- |
+| 1 | Source Identity Contract | 4 pts | backend-architect, data-layer-expert | Define canonical path/source-key rules and tests. |
+| 2 | Ingest Path Canonicalization | 7 pts | python-backend-engineer, data-layer-expert | Use canonical source keys for sync and session writes. |
+| 3 | Duplicate Migration And Backfill | 5 pts | data-layer-expert, python-backend-engineer | Collapse existing host/container duplicate state safely. |
+| 4 | Runtime Guardrails And Operator Docs | 3 pts | DevOps, documentation-writer | Reduce accidental polling/broad-sync churn and document validation. |
+| 5 | Performance Validation Gate | 5 pts | performance-engineer, task-completion-validator | Prove startup idempotence, idle CPU stability, and no memory leak signal. |
+
+## Phase 1: Source Identity Contract
+
+Assigned Subagents: backend-architect, data-layer-expert
+
+| Task ID | Task Name | Description | Acceptance Criteria | Estimate | Dependencies |
+| --- | --- | --- | --- | ---: | --- |
+| SRC-001 | Canonical Source Identity Design | Define a single source identity contract for filesystem-derived session, document, progress, and test files. Cover project-root paths, `~/.claude`, `~/.codex`, container home remaps, and optional mount slots. | Contract document or code comments identify canonical inputs, outputs, collision behavior, and rollout constraints. | 1 pt | None |
+| SRC-002 | Path Canonicalization Helper | Add a helper that maps host and container aliases to a stable source key before repository lookup/write. Prefer project registry path config and mounted root aliases over ad hoc string replacement. | Unit tests prove `/Users/miethe/.claude/...` and `/home/ccdash/.claude/...` map to the same key for the same project. | 2 pts | SRC-001 |
+| SRC-003 | Collision And Escape Tests | Cover symlinks, non-mounted paths, optional mount slots, unrelated projects, and paths outside known roots. | Unknown paths remain stable and do not collapse across projects; known aliases collapse only when they represent the same source. | 1 pt | SRC-002 |
+
+Quality gates:
+
+1. Canonicalization is deterministic and side-effect free.
+2. The helper does not require a live container runtime.
+3. Tests cover both host and container path forms.
+
+## Phase 2: Ingest Path Canonicalization
+
+Assigned Subagents: python-backend-engineer, data-layer-expert
+
+| Task ID | Task Name | Description | Acceptance Criteria | Estimate | Dependencies |
+| --- | --- | --- | --- | ---: | --- |
+| ING-001 | Sync State Lookup Boundary | Update `sync_repo.get_sync_state`, `upsert_sync_state`, and delete usage sites so startup sync checks canonical source identity before deciding a file is new. | A second startup under container paths skips files already synced under host paths when content/mtime is unchanged. | 2 pts | SRC-002 |
+| ING-002 | Session Source File Persistence | Normalize `sessions.source_file` at write boundaries or add an explicit canonical source column while preserving compatibility for display/debug payloads. | Existing API consumers keep source display behavior, but repository uniqueness and deletes use canonical identity. | 2 pts | SRC-002 |
+| ING-003 | Delete/Replace Scope Hardening | Ensure `delete_by_source`, relationship deletes, canonical messages, telemetry replacement, and usage attribution replacement do not duplicate rows when the same physical file appears through an alias path. | Re-ingesting one aliased file does not double `session_messages`, `telemetry_events`, or `session_usage_attributions`. | 2 pts | ING-001, ING-002 |
+| ING-004 | Live Fanout Idempotence | Confirm publish counts reflect real changed sessions, not alias re-ingestion. Preserve invalidation-only Postgres fanout behavior. | `worker-watch` publishes no bulk duplicate fanout events on second startup with unchanged files. | 1 pt | ING-003 |
+
+Quality gates:
+
+1. Existing local SQLite tests still pass.
+2. Existing Postgres repository tests still pass.
+3. The fix applies to both startup sync and watcher-triggered changed-file sync.
+
+## Phase 3: Duplicate Migration And Backfill
+
+Assigned Subagents: data-layer-expert, python-backend-engineer
+
+| Task ID | Task Name | Description | Acceptance Criteria | Estimate | Dependencies |
+| --- | --- | --- | --- | ---: | --- |
+| MIG-001 | Duplicate Audit Queries | Add repeatable SQL or a CLI/admin script that reports host/container alias duplicates in `sync_state`, `sessions`, and derived tables. | The script reports counts equivalent to the 2026-05-04 investigation and exits non-zero only on query failure. | 1 pt | SRC-002 |
+| MIG-002 | Safe Collapse Strategy | Define how to choose survivor rows and update or delete duplicate rows without losing newer mtime/hash data or canonical transcript rows. | Strategy is restart-safe, dry-run first, and scoped by project id. | 1 pt | MIG-001 |
+| MIG-003 | Migration Tool | Implement a project-scoped dry-run/apply command for duplicate source identity collapse. | Dry run prints affected source keys and row counts; apply is idempotent and records operation evidence. | 2 pts | MIG-002 |
+| MIG-004 | Post-Migration Verification | Verify table counts, live feature/session views, and source lookup behavior after cleanup. | No duplicate host/container source identities remain for the target project; session counts remain explainable. | 1 pt | MIG-003 |
+
+Quality gates:
+
+1. Migration cannot run without explicit project id.
+2. Migration has dry-run output suitable for review before apply.
+3. Rollback plan is documented as restoring from the Postgres volume backup or transaction snapshot.
+
+## Phase 4: Runtime Guardrails And Operator Docs
+
+Assigned Subagents: DevOps, documentation-writer
+
+| Task ID | Task Name | Description | Acceptance Criteria | Estimate | Dependencies |
+| --- | --- | --- | --- | ---: | --- |
+| OPS-001 | Polling Mode Guardrail | Keep `WATCHFILES_FORCE_POLLING` scoped to `worker-watch`, but document that it increases sustained CPU and should be disabled after event delivery is confirmed. | `deploy/runtime/README.md` distinguishes startup sync load from idle polling load and lists expected validation commands. | 1 pt | None |
+| OPS-002 | Port Conflict Guidance | Document that host `127.0.0.1:8000` can be occupied by another dev server and that `127.0.0.1:3131/api/health/ready` or container-internal probes are safer for stack validation. | Runtime smoke docs include a port-conflict check using `lsof -nP -iTCP:8000 -sTCP:LISTEN`. | 1 pt | None |
+| OPS-003 | Watch Scope Guidance | Document how `sessionsPath`, `.claude`, `.codex`, workspace roots, and optional mounts affect watch size and startup cost. | Docs call out that broad global session roots can contain thousands of JSONL files and should be intentional. | 1 pt | SRC-001 |
+
+Quality gates:
+
+1. Docs use `docker-compose` for this environment and do not assume standalone `docker`.
+2. Docs include expected CPU/RAM interpretation rather than only commands.
+3. Docs do not present polling mode as a default performance setting.
+
+## Phase 5: Performance Validation Gate
+
+Assigned Subagents: performance-engineer, task-completion-validator
+
+| Task ID | Task Name | Description | Acceptance Criteria | Estimate | Dependencies |
+| --- | --- | --- | --- | ---: | --- |
+| VAL-001 | Startup Idempotence Smoke | Start the stack, wait for `worker-watch` startup sync to complete, stop/start again, and compare sync/fanout/write counts. | Second startup does not bulk re-ingest already-synced session files under alias paths. | 2 pts | ING-004, MIG-004 |
+| VAL-002 | Idle CPU And Memory Window | After startup completes, sample `docker-compose stats --no-stream` every 30 seconds for 10 minutes with no file changes. | `worker-watch` CPU stays low outside polling/event bursts; RSS does not grow monotonically across the sample. | 1 pt | VAL-001 |
+| VAL-003 | Postgres Churn Check | Capture relation stats for `sessions`, `session_messages`, `telemetry_events`, `session_usage_attributions`, and `sync_state` before and after second startup. | Rows and dead tuples do not grow materially on unchanged second startup. | 1 pt | VAL-001 |
+| VAL-004 | Regression Suite | Run focused backend tests for file watcher, runtime bootstrap, Postgres live fanout, sync engine session writes, and new canonicalization/migration tests. | Focused tests pass; any known environment caveats are documented with exact command output. | 1 pt | ING-004, MIG-004 |
+
+Quality gates:
+
+1. Validation uses the same `docker-compose --env-file deploy/runtime/.env -f deploy/runtime/compose.yaml --profile enterprise --profile postgres --profile live-watch` surface.
+2. CPU/RAM evidence includes startup and idle windows.
+3. Postgres evidence includes table stats and active query sampling.
+
+## Risks And Mitigations
+
+| Risk | Severity | Mitigation |
+| --- | --- | --- |
+| Canonicalization collapses distinct files that only look similar by path suffix. | High | Include project id and configured mount/root identity in the source key; test unrelated roots. |
+| Migration deletes useful historical rows. | High | Dry-run first, project-scoped apply, transactional operations, backup/restore runbook. |
+| UI/debug surfaces lose useful source path display. | Medium | Preserve display path separately from canonical identity when needed. |
+| Local SQLite and enterprise Postgres diverge. | Medium | Add parity tests for both repository paths where feasible. |
+| Polling remains high CPU after canonicalization. | Medium | Validate idle CPU separately with polling on/off; document polling as compatibility mode. |
+
+## Validation Commands
+
+Use these commands during implementation validation:
+
+```bash
+docker-compose --env-file deploy/runtime/.env \
+  -f deploy/runtime/compose.yaml \
+  --profile enterprise --profile postgres --profile live-watch ps
+
+docker-compose --env-file deploy/runtime/.env \
+  -f deploy/runtime/compose.yaml \
+  --profile enterprise --profile postgres --profile live-watch stats --no-stream
+
+curl -fsS http://127.0.0.1:9466/detailz | jq '.detail.worker.jobs.startupSync, .detail.liveFanout'
+
+curl -fsS http://127.0.0.1:3131/api/health/ready | jq .
+
+docker-compose --env-file deploy/runtime/.env \
+  -f deploy/runtime/compose.yaml \
+  --profile enterprise --profile postgres --profile live-watch exec -T postgres \
+  psql -U ccdash -d ccdash -c "select relname, n_live_tup, n_dead_tup, n_tup_ins, n_tup_del from pg_stat_user_tables where relname in ('sessions','session_messages','telemetry_events','session_usage_attributions','sync_state') order by relname;"
+```
+
+## Success Criteria
+
+1. Host and container runtime aliases resolve to the same source identity for the same physical session file.
+2. A second unchanged `worker-watch` startup does not duplicate session rows or produce bulk live fanout.
+3. Startup CPU and Postgres I/O remain explainable by real changed work.
+4. Idle `worker-watch` CPU is low when polling is disabled and bounded when polling is enabled.
+5. Operator docs distinguish port conflicts, startup sync load, polling load, and actual leak signals.
+
+## Deferred Items
+
+1. A broader ingestion service extraction is deferred to future architecture work. This plan only hardens source identity and duplicate cleanup.
+2. Changing the default deployment port away from `8000` is deferred unless port conflicts become a frequent operator issue.
+3. Rewriting telemetry event insertion to use batched Postgres `executemany` or copy protocol is deferred unless post-canonicalization validation still shows unacceptable startup duration.

--- a/docs/project_plans/implementation_plans/infrastructure/live-ingest-source-path-canonicalization-hardening-v1.md
+++ b/docs/project_plans/implementation_plans/infrastructure/live-ingest-source-path-canonicalization-hardening-v1.md
@@ -3,14 +3,14 @@ schema_name: ccdash_document
 schema_version: 3
 doc_type: implementation_plan
 doc_subtype: hardening_plan
-status: in-progress
+status: completed
 category: infrastructure
 title: Live Ingest Source Path Canonicalization Hardening V1 - Implementation Plan
 description: Hardening plan to stop worker-watch container path drift from causing duplicate session ingestion and excessive Postgres startup churn.
 summary: Canonicalize filesystem-derived session source identity across host and container runtimes, migrate duplicate sync state safely, and add operator validation for startup CPU, memory, and Postgres write amplification.
 author: codex
 created: 2026-05-04
-updated: 2026-05-04
+updated: 2026-05-05
 audience:
   - ai-agents
   - developers
@@ -53,6 +53,18 @@ commit_refs:
   - 7e57c7f
   - 0577e4c
   - f0c106a
+  - 31c9c92
+  - b637d43
+  - a311f79
+  - e6a6baf
+  - 148b098
+  - 200eb00
+  - 07d8d73
+  - 015e0a8
+  - d609db2
+  - ebc2a45
+  - b64024b
+  - 36effc0
 pr_refs: []
 files_affected:
   - backend/db/sync_engine.py
@@ -60,6 +72,9 @@ files_affected:
   - backend/tests/test_file_watcher.py
   - backend/tests/test_sync_engine_linking.py
   - backend/tests/test_source_identity.py
+  - backend/scripts/source_alias_duplicate_audit.py
+  - backend/tests/test_source_alias_duplicate_audit.py
+  - deploy/runtime/README.md
   - .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-1-progress.md
   - .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-2-progress.md
   - .claude/progress/live-ingest-source-path-canonicalization-hardening-v1/phase-3-progress.md


### PR DESCRIPTION
## Summary
- Canonicalized filesystem-derived live-ingest source identity across host/container aliases and wired the sync engine to use canonical keys at lookup and write boundaries.
- Added a project-scoped duplicate audit and collapse workflow for legacy alias drift, with dry-run and apply paths plus focused tests.
- Updated runtime docs to separate startup reconciliation from idle polling, explain port-conflict checks, and document watch-scope cost.
- Closed out phases 1-5 progress trackers and the implementation plan status.

## Testing
- Focused backend tests passed for source identity, sync-engine linkage, file watcher behavior, and the new source-alias audit/collapse coverage.
- Live compose validation confirmed startup idempotence, steady Postgres table counts across restart, and no bulk duplicate re-ingest on a second worker-watch startup.
- Regression validation is recorded, with one runtime bootstrap pytest collection issue noted as an environment/import caveat rather than a product regression.